### PR TITLE
Song parser 2

### DIFF
--- a/UltraStar Play/Assets/src/model/song/Song.cs
+++ b/UltraStar Play/Assets/src/model/song/Song.cs
@@ -8,10 +8,10 @@ public class Song
 {
     private readonly string m_path;
     private readonly string m_folderPath;
-    private readonly List<List<Sentence>> m_voicesSentences;
+    private readonly List<Voice> m_voices;
     private readonly Dictionary<ESongHeader, System.Object> m_headers;
 
-    public Song(Dictionary<ESongHeader, System.Object> headers, List<List<Sentence>> voicesSentences, string path)
+    public Song(Dictionary<ESongHeader, System.Object> headers, List<Voice> voices, string path)
     {
         if(headers == null || headers.Count == 0)
         {
@@ -19,11 +19,11 @@ public class Song
         }
         m_headers = headers;
 
-        if (voicesSentences == null || voicesSentences.Count == 0 || voicesSentences[0] == null)// || playerSentences[0].Count == 0)
+        if (voices == null || voices.Count == 0 || voices[0] == null)// || playerSentences[0].Count == 0)
         {
-            throw new UnityException("playerSentences is null or empty! Can not initialize Song.");
+            throw new UnityException("voices is null or empty! Can not initialize Song.");
         }
-        m_voicesSentences = voicesSentences;
+        m_voices = voices;
 
         if(path == null || path.Length < 6 || !File.Exists(path))
         {
@@ -33,14 +33,14 @@ public class Song
         m_folderPath = new FileInfo(path).Directory.FullName;
     }
 
-    public ReadOnlyCollection<Sentence> GetSentences(int voiceNr)
-    {
-        if(voiceNr > (m_voicesSentences.Count -1))
-        {
-            throw new UnityException("Invalid voiceNumber. Can not get sentences for that player!");
-        }
-        return m_voicesSentences[voiceNr].AsReadOnly();
-    }
+    //~ public ReadOnlyCollection<Sentence> GetSentences(int voiceNr)
+    //~ {
+        //~ if(voiceNr > (m_voices.Count -1))
+        //~ {
+            //~ throw new UnityException("Invalid voiceNumber. Can not get sentences for that player!");
+        //~ }
+        //~ return m_voices[voiceNr].AsReadOnly();
+    //~ }
 
     public string GetStringHeaderOrNull(ESongHeader key)
     {
@@ -74,6 +74,6 @@ public class Song
     }
     public bool IsDuet()
     {
-        return (m_voicesSentences.Count == 2 || m_voicesSentences.Count == 3);
+        return (m_voices.Count == 2 || m_voices.Count == 3);
     }
 }

--- a/UltraStar Play/Assets/src/model/song/SongBuilder.cs
+++ b/UltraStar Play/Assets/src/model/song/SongBuilder.cs
@@ -13,11 +13,6 @@ public class SongBuilder
             m_notes.Add(note);
         }
 
-        public List<Note> GetNotes()
-        {
-            return m_notes;
-        }
-
         public Sentence AsSentence()
         {
             return new Sentence(m_notes, GetStartBeat(), GetEndBeat());

--- a/UltraStar Play/Assets/src/model/song/SongBuilder.cs
+++ b/UltraStar Play/Assets/src/model/song/SongBuilder.cs
@@ -1,0 +1,207 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+public class SongBuilder
+{
+    // mutable versions of some objects
+    private class MutableSentence
+    {
+        private List<Note> m_notes = new List<Note>();
+
+        public void AddNote(Note note)
+        {
+            m_notes.Add(note);
+        }
+
+        public List<Note> GetNotes()
+        {
+            return m_notes;
+        }
+
+        public Sentence AsSentence()
+        {
+            return new Sentence(m_notes, GetStartBeat(), GetEndBeat());
+        }
+
+        private uint GetStartBeat()
+        {
+            return m_notes[0].GetStartBeat();
+        }
+
+        private uint GetEndBeat()
+        {
+            Note lastNote = m_notes[m_notes.Count-1];
+            return lastNote.GetStartBeat() + lastNote.GetLength();
+        }
+    }
+
+    private class MutableVoice
+    {
+        private readonly string m_name;
+        private List<Sentence> m_sentences = new List<Sentence>();
+
+        public MutableVoice(string name)
+        {
+            m_name = name;
+        }
+
+        public string GetName()
+        {
+            return m_name;
+        }
+
+        public void AddSentence(Sentence sentence)
+        {
+            m_sentences.Add(sentence);
+        }
+
+        public Voice AsVoice(){
+            return new Voice(m_name, m_sentences);
+        }
+    }
+
+    private class MutableSong
+    {
+        private readonly string m_path;
+        private Dictionary<ESongHeader, System.Object> m_headers = new Dictionary<ESongHeader, System.Object>();
+        private Dictionary<string, MutableVoice> m_voices = new Dictionary<string, MutableVoice>(); // P# -> MutableVoice
+
+        public MutableSong(string path)
+        {
+            m_path = path;
+        }
+
+        // todo: this can probably maybe get split out into setting individual headers, but for now It'll Be OK
+        public void SetHeaders(Dictionary<ESongHeader, System.Object> headers)
+        {
+            m_headers = headers;
+        }
+
+        public Dictionary<ESongHeader, System.Object> GetHeaders()
+        {
+            return m_headers;
+        }
+
+        public void AddVoice(string identifier, string name)
+        {
+            m_voices.Add(identifier, new MutableVoice(name));
+        }
+
+        public void FixVoices()
+        {
+            // remove any DUETSINGERP voices for which a P voice also exists
+            // then, change any remaining DUETSINGERP voice to a P voice
+            List<string> voicesToRemove = new List<string>();
+            List<string> voicesToRename = new List<string>();
+            foreach (string identifier in m_voices.Keys)
+            {
+                if (identifier.StartsWith("DUETSINGERP"))
+                {
+                    if (m_voices.ContainsKey(identifier.Substring(10)))
+                    {
+                        voicesToRemove.Add(identifier);
+                    }
+                    else
+                    {
+                        voicesToRename.Add(identifier);
+                    }
+                }
+            }
+            foreach (string identifier in voicesToRemove)
+            {
+                m_voices.Remove(identifier);
+            }
+            foreach (string identifier in voicesToRename)
+            {
+                string name = m_voices[identifier].GetName();
+                m_voices.Remove(identifier);
+                AddVoice(identifier.Substring(10), name);
+            }
+        }
+
+        public int GetNumberOfVoices()
+        {
+            return m_voices.Count;
+        }
+
+        public MutableVoice GetVoice(string identifier)
+        {
+            return m_voices[identifier];
+        }
+
+        public Song AsSong()
+        {
+            List<Voice> voices = new List<Voice>();
+            foreach (MutableVoice voice in m_voices.Values)
+            {
+                voices.Add(voice.AsVoice());
+            }
+            return new Song(m_headers, voices, m_path);
+        }
+    }
+
+    private MutableVoice m_currentVoice;
+    private MutableSentence m_currentSentence;
+    private MutableSong m_song;
+
+    public SongBuilder(string path)
+    {
+        m_song = new MutableSong(path);
+    }
+
+    public void SaveCurrentSentence()
+    {
+        if (m_currentSentence == null)
+        {
+            return;
+        }
+        if (m_currentVoice == null && m_song.GetNumberOfVoices() == 0)
+        {
+            // some default voice if it was never set, aka most solo songs
+            m_song.AddVoice("_", "_");
+            m_currentVoice = m_song.GetVoice("_");
+        }
+        m_currentVoice.AddSentence(m_currentSentence.AsSentence());
+        m_currentSentence = null;
+    }
+
+    public void SetCurrentVoice(string identifier)
+    {
+        m_currentVoice = m_song.GetVoice(identifier);
+    }
+
+    public void AddVoice(string identifier, string name)
+    {
+        m_song.AddVoice(identifier, name);
+    }
+
+    public void FixVoices()
+    {
+        m_song.FixVoices();
+    }
+
+    public void AddNote(Note note)
+    {
+        if (m_currentSentence == null)
+        {
+            m_currentSentence = new MutableSentence();
+        }
+        m_currentSentence.AddNote(note);
+    }
+
+    // todo: this can probably maybe get split out into setting individual headers, but for now It'll Be OK
+    public void SetSongHeaders(Dictionary<ESongHeader, System.Object> headers)
+    {
+        m_song.SetHeaders(headers);
+    }
+
+    public Dictionary<ESongHeader, System.Object> GetSongHeaders()
+    {
+        return m_song.GetHeaders();
+    }
+
+    public Song AsSong()
+    {
+        return m_song.AsSong();
+    }
+}

--- a/UltraStar Play/Assets/src/model/song/Voice.cs
+++ b/UltraStar Play/Assets/src/model/song/Voice.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Voice
+{
+    private readonly string m_name;
+    private readonly List<Sentence> m_sentences;
+    
+    public Voice(string name, List<Sentence> sentences)
+    {
+        if (name == null || name.Length < 1)
+        {
+            throw new UnityException("name is null or empty!");
+        }
+        m_name = name;
+        if (sentences == null || sentences.Count < 1)
+        {
+            throw new UnityException("sentences is null or empty!");
+        }
+        m_sentences = sentences;
+    }
+
+    public string getName()
+    {
+        return m_name;
+    }
+
+    public List<Sentence> getSentences()
+    {
+        return m_sentences;
+    }
+}

--- a/UltraStar Play/Assets/src/model/song/sentence/note/Note.cs
+++ b/UltraStar Play/Assets/src/model/song/sentence/note/Note.cs
@@ -4,11 +4,11 @@ using UnityEngine;
 
 public class Note
 {
-    public readonly int m_pitch;
-    public readonly uint m_startBeat;
-    public readonly uint m_length;
-    public readonly string m_text;
-    public readonly ENoteType m_type;
+    private readonly int m_pitch;
+    private readonly uint m_startBeat;
+    private readonly uint m_length;
+    private readonly string m_text;
+    private readonly ENoteType m_type;
 
     public Note(int pitch, uint startBeat, uint length, string text, ENoteType type)
     {

--- a/UltraStar Play/Assets/src/model/song/sentence/note/Note.cs
+++ b/UltraStar Play/Assets/src/model/song/sentence/note/Note.cs
@@ -5,17 +5,27 @@ using UnityEngine;
 public class Note
 {
     public readonly int m_pitch;
-    public readonly int m_startBeat;
-    public readonly int m_length;
+    public readonly uint m_startBeat;
+    public readonly uint m_length;
     public readonly string m_text;
     public readonly ENoteType m_type;
 
-    public Note(int pitch, int startBeat, int length, string text, ENoteType type)
+    public Note(int pitch, uint startBeat, uint length, string text, ENoteType type)
     {
         m_pitch = pitch;
         m_startBeat = startBeat;
         m_length = length;
         m_text = text;
         m_type = type;
+    }
+
+    public uint GetLength()
+    {
+        return m_length;
+    }
+
+    public uint GetStartBeat()
+    {
+        return m_startBeat;
     }
 }

--- a/UltraStar Play/Assets/src/model/song/sentence/note/Note.cs
+++ b/UltraStar Play/Assets/src/model/song/sentence/note/Note.cs
@@ -24,8 +24,23 @@ public class Note
         return m_length;
     }
 
+    public int GetPitch()
+    {
+        return m_pitch;
+    }
+
     public uint GetStartBeat()
     {
         return m_startBeat;
+    }
+
+    public string GetText()
+    {
+        return m_text;
+    }
+
+    public ENoteType GetType()
+    {
+        return m_type;
     }
 }

--- a/UltraStar Play/Assets/src/view/base/SLoadingController.cs
+++ b/UltraStar Play/Assets/src/view/base/SLoadingController.cs
@@ -15,9 +15,10 @@ public class SLoadingController : MonoBehaviour
         {
             Debug.Log("Name: " + device);
         }
+        SongsManager.ScanSongFiles();
     }
 
-	void Update ()
+    void Update ()
     {
         if(m_labelStatus != null)
         {


### PR DESCRIPTION
### What does this PR do?
* This PR is the same as #25 but with the correct branching
* Adds a SongBuilder object to make parsing life easier
* Adds a Voice object, which is basically m_voicesSentences but also has the player name
* It also changes a stray tab to spaces somewhere, which isn't really related to this PR but I was working like 1 line above it anyway.
* I didn't add the .meta files because I use a different Unity version. Either someone with a correct version should add them, or just gitignore them.
* I couldn't find anything regarding rap notes, but they weren't there before either.
* It will not shift overlapping notes/sentences anymore, perhaps it's better to do that in a separate function after the parsing is done.
* The specific beat at which a linebreak occurs is not saved anywhere (though I don't think it did that to begin with). It's probably better to just make some 'algorithm' to compute the optimal linebreak beat between two sentences at a later stage? In USDX linebreaks happen when the file tells it to, which sounds nice but is completely inconsistent between songs that have long breaks in them: one will have the previous sentence on it for ages, another song the next sentence. It's also annoying in the USDX editor, but I'll make a separate issue for this.