### PR TITLE
Some essential parsing fixes without any tests

### DIFF
--- a/UltraStar Play/Assets/src/model/song/builder/SongMetaBuilder.cs
+++ b/UltraStar Play/Assets/src/model/song/builder/SongMetaBuilder.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Text;
+using System.Text.RegularExpressions;
 
 static class SongMetaBuilder
 {
@@ -63,7 +64,7 @@ static class SongMetaBuilder
                 {
                     requiredFields[tag] = val;
                 }
-                else if (tag.StartsWith("p", StringComparison.Ordinal) && tag.Length > 1)
+                else if (tag.StartsWith("p", StringComparison.Ordinal) && tag.Length > 1 && Regex.IsMatch(tag, @"^p\d+$"))
                 {
                     if (!voiceNames.ContainsKey(tag.ToUpperInvariant()))
                     {
@@ -71,7 +72,7 @@ static class SongMetaBuilder
                     }
                     // silently ignore already set voiceNames
                 }
-                else if (tag.StartsWith("duetsingerp", StringComparison.Ordinal) && tag.Length > 11)
+                else if (tag.StartsWith("duetsingerp", StringComparison.Ordinal) && tag.Length > 11 && Regex.IsMatch(tag, @"^duetsingerp\d+$"))
                 {
                     string shorttag = tag.Substring(10).ToUpperInvariant();
                     if (!voiceNames.ContainsKey(shorttag))

--- a/UltraStar Play/Assets/src/model/song/builder/VoicesBuilder.cs
+++ b/UltraStar Play/Assets/src/model/song/builder/VoicesBuilder.cs
@@ -122,7 +122,9 @@ static class VoicesBuilder
 
     private static uint ParseLinebreak(string line)
     {
-        return ConvertToUInt32(line);
+        // workaround for linebreaks with multiple beats (where no lyrics are on screen for a while)
+        // for now, just use the first value and ignore everything else
+        return ConvertToUInt32(line.Split(' ')[0]);
     }
 
     private static Note ParseNote(string line)
@@ -180,6 +182,10 @@ static class VoicesBuilder
             return Convert.ToUInt32(s, 10);
         }
         catch (FormatException e)
+        {
+            throw new VoicesBuilderException("Could not convert "+s+" to an uint. Reason: "+e.Message);
+        }
+        catch (OverflowException e)
         {
             throw new VoicesBuilderException("Could not convert "+s+" to an uint. Reason: "+e.Message);
         }


### PR DESCRIPTION
### What does this PR do?

Parse more things that are probably okay to parse. It's mostly so that it doesn't completely break on a significant portion of currently already existing songs. In detail, it fixes:
- support for the '- beat1 beat2' linebreak format (or more specifically, it just ignores everything after the first beat. I know it's a 'feature' in USDX.
- adds some overflow exception catches to int parsing

_Yes_ it is super much behind master at this point, and _yes_ it also does not have any tests. I'm only making this pull request because in the past four months, I've just not found the time to make it a proper pull request. It should be fairly trivial to a) decide if you want to support these things at all and b) reimplement them (with proper tests) in the current master.

Maybe it's already in the current master, if so you can just close this PR.

### Motivation

While fixing songs from the MLK project, I discovered some missing 'features' that we might or might not want to support.