### PR TITLE
SingScene: fix issues with wrong calculation of song durations / positions

### DIFF
--- a/UltraStar Play/Assets/Common/Audio/Recording/CamdAudioSamplesAnalyzer.cs
+++ b/UltraStar Play/Assets/Common/Audio/Recording/CamdAudioSamplesAnalyzer.cs
@@ -77,7 +77,9 @@ public class CamdAudioSamplesAnalyzer : IAudioSamplesAnalyzer
         }
         if (!passesThreshhold)
         {
-            return;
+            // Subscribers (such as the PlayerNoteRecorder) must know that the singing ended.
+            // Therefore, a midi pitch of 0 is interpreted as "no singing".
+            OnPitchDetected(0);
         }
 
         // get best fitting tone

--- a/UltraStar Play/Assets/Scenes/Sing/SingScene.unity
+++ b/UltraStar Play/Assets/Scenes/Sing/SingScene.unity
@@ -487,9 +487,9 @@ MonoBehaviour:
   anchorMin: {x: 0.5, y: 0.1}
   anchorMax: {x: 0.5, y: 1}
   pivot: {x: 0.5, y: 0.5}
-  localPosition: {x: 0, y: 1.6979418, z: 0}
+  localPosition: {x: 0, y: 1.6096449, z: 0}
   sizeDelta: {x: 2, y: 0}
-  size: {x: 2, y: 30.564054}
+  size: {x: 2, y: 28.974703}
 --- !u!1 &320770002
 GameObject:
   m_ObjectHideFlags: 0
@@ -612,9 +612,9 @@ MonoBehaviour:
   anchorMin: {x: 0, y: 0}
   anchorMax: {x: 0, y: 0}
   pivot: {x: 0.5, y: 0.5}
-  localPosition: {x: 515.5, y: 309.5, z: 0}
-  sizeDelta: {x: 799.99994, y: 480.31036}
-  size: {x: 799.99994, y: 480.31036}
+  localPosition: {x: 515.5, y: 293.5, z: 0}
+  sizeDelta: {x: 799.99994, y: 455.4801}
+  size: {x: 799.99994, y: 455.4801}
 --- !u!1 &475691986
 GameObject:
   m_ObjectHideFlags: 0
@@ -1464,9 +1464,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0c11810cb9527c047beda7fd4b488be2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  positionInSongDelayInMillis: 150
-  volume: 1
-  defaultSongName: Marry You
+  defaultSongName: Summer Wine
   defaultSongNamePasteBin: 'Summer Wine
 
     EmptyTitle

--- a/UltraStar Play/Assets/Scenes/Sing/TimeBar/TimeBarTimeLine.cs
+++ b/UltraStar Play/Assets/Scenes/Sing/TimeBar/TimeBarTimeLine.cs
@@ -7,28 +7,7 @@ public class TimeBarTimeLine : MonoBehaviour
 {
     public TimeBarTimeLineRect timeLineRectPrefab;
 
-    private SingSceneController singSceneController;
-    private bool isInitialized;
-
-    void OnEnable()
-    {
-        isInitialized = false;
-    }
-
-    void Update()
-    {
-        if (!isInitialized)
-        {
-            isInitialized = true;
-            singSceneController = SingSceneController.Instance;
-            double durationOfSongInMillis = singSceneController.DurationOfSongInMillis;
-            SongMeta songMeta = singSceneController.SongMeta;
-            List<PlayerController> playerControllers = singSceneController.PlayerControllers;
-            Init(songMeta, playerControllers, durationOfSongInMillis);
-        }
-    }
-
-    private void Init(SongMeta songMeta, List<PlayerController> playerControllers, double durationOfSongInMillis)
+    public void Init(SongMeta songMeta, List<PlayerController> playerControllers, double durationOfSongInMillis)
     {
         foreach (TimeBarTimeLineRect timeLineRect in GetComponentsInChildren<TimeBarTimeLineRect>())
         {
@@ -48,11 +27,12 @@ public class TimeBarTimeLine : MonoBehaviour
             double startPosInMillis = BpmUtils.BeatToMillisecondsInSong(songMeta, sentence.StartBeat);
             double endPosInMillis = BpmUtils.BeatToMillisecondsInSong(songMeta, sentence.EndBeat);
             PlayerProfile playerProfile = playerController.PlayerProfile;
-            CreateTimeLineRect(playerProfile, startPosInMillis, endPosInMillis, durationOfSongInMillis);
+            MicProfile micProfile = playerController.MicProfile;
+            CreateTimeLineRect(playerProfile, micProfile, startPosInMillis, endPosInMillis, durationOfSongInMillis);
         }
     }
 
-    private void CreateTimeLineRect(PlayerProfile playerProfile, double startPosInMillis, double endPosInMillis, double durationOfSongInMillis)
+    private void CreateTimeLineRect(PlayerProfile playerProfile, MicProfile micProfile, double startPosInMillis, double endPosInMillis, double durationOfSongInMillis)
     {
         double startPosPercentage = startPosInMillis / durationOfSongInMillis;
         double endPosPercentage = endPosInMillis / durationOfSongInMillis;
@@ -69,6 +49,9 @@ public class TimeBarTimeLine : MonoBehaviour
         rectTransform.sizeDelta = Vector2.zero;
 
         // Set color of rect to color of mic.
-        singSceneController.GetMicProfile(playerProfile).IfNotNull(micProfile => timeLineRect.SetColor(micProfile.Color));
+        if (micProfile != null)
+        {
+            timeLineRect.SetColor(micProfile.Color);
+        }
     }
 }


### PR DESCRIPTION
### What does this PR do?

Fix some issues.
Conversion of duration-in-millis to duration-in-seconds was using multiply instead of division.
Furthermore, the duration of the song is not known directly at the start of the scene. The song is loaded first and afterwards the duration is known. Because of this, the init of the TimeBar had to be moved.