### PR TITLE
SingSceneController: fixed premature FinishScene

### DIFF
--- a/UltraStar Play/Assets/Scenes/Sing/SingSceneController.cs
+++ b/UltraStar Play/Assets/Scenes/Sing/SingSceneController.cs
@@ -286,6 +286,24 @@ public class SingSceneController : MonoBehaviour, IOnHotSwapFinishedListener
         SceneNavigator.Instance.LoadScene(EScene.SongEditorScene, songEditorSceneData);
     }
 
+    private void CheckSongFinished()
+    {
+        if (audioPlayer.clip == null || DurationOfSongInMillis == 0)
+        {
+            return;
+        }
+
+        double missingMillis = DurationOfSongInMillis - PositionInSongInMillis;
+        if (missingMillis <= 0)
+        {
+            Invoke("FinishScene", 1f);
+        }
+        else
+        {
+            Invoke("CheckSongFinished", (float)(missingMillis / 1000.0));
+        }
+    }
+
     public void FinishScene()
     {
         // Open the singing results scene.
@@ -524,7 +542,7 @@ public class SingSceneController : MonoBehaviour, IOnHotSwapFinishedListener
                 InitTimeBar();
 
                 // Go to next scene when the song finishes
-                Invoke("FinishScene", (float)DurationOfSongInMillis / 1000.0f);
+                CheckSongFinished();
             }
         }
 


### PR DESCRIPTION
### What does this PR do?

Fixes the following issue that I introduces with my last PR: 

> Songs now sometimes quit early (for example when the last third of the song was just reached). They sometimes even quit while the gameplay was paused using spacebar key.
