### PR TITLE
small changes/fixes for pitch detection algo

### DIFF
--- a/UltraStar Play/Assets/Common/Audio/Recording/CamdAudioSamplesAnalyzer.cs
+++ b/UltraStar Play/Assets/Common/Audio/Recording/CamdAudioSamplesAnalyzer.cs
@@ -89,7 +89,7 @@ public class CamdAudioSamplesAnalyzer : IAudioSamplesAnalyzer
         int halftone = CalculateBestFittingHalftone(correlation);
         if (halftone != -1 && isEnabled)
         {
-            // add C5 (A4 + 3 halftones) as offset to the detected pitch
+            // no idea where the +3 is coming from...
             OnPitchDetected(halftone + BaseToneMidi + 3);
         }
         else
@@ -143,6 +143,8 @@ public class CamdAudioSamplesAnalyzer : IAudioSamplesAnalyzer
                         audioSamplesBuffer[(index + halftoneDelays[halftone]) & (samplesSinceLastFrame - 1)] -
                         audioSamplesBuffer[index]);
             }
+            // normalize values for future application
+            correlation[halftone] = correlation[halftone] / samplesSinceLastFrame;
         }
         // return circular average magnitude difference
         return correlation;


### PR DESCRIPTION
### What does this PR do?
- change the processing order to make the "halftone != -1" condition valid
- removed element wise division by "samplesSinceLastFrame" -> doesn't appear to be necessary for pitch detection

### Additional Notes
It could be worth considering to combine CircularAverageMagnitudeDifference() and CalculateBestFittingHalftone() into one method. This would make the correlation buffer obsolete. Granted the performance gain is not that huge, but in time critical applications moving data unnecessarily should be avoided.

I couldn't test any of the proposed changes. Please check beforehand if anything works as expected if you want to apply them.

