### PR TITLE
various fixes

### DIFF
--- a/UltraStar Play/Assets/Common/Audio/Recording/CamdAudioSamplesAnalyzer.cs
+++ b/UltraStar Play/Assets/Common/Audio/Recording/CamdAudioSamplesAnalyzer.cs
@@ -14,16 +14,14 @@ public class CamdAudioSamplesAnalyzer : IAudioSamplesAnalyzer
     private static readonly double[] halftoneFrequencies = PrecalculateHalftoneFrequencies();
 
     private readonly int[] halftoneDelays;
-    private readonly Subject<PitchEvent> pitchEventStream;
     private readonly List<int> pitchRecordHistory = new List<int>();
     private readonly int pitchRecordHistoryLength = 5;
 
     private bool isEnabled;
     private int lastPitchDetectedFrame;
 
-    public CamdAudioSamplesAnalyzer(Subject<PitchEvent> pitchEventStream, int sampleRateHz)
+    public CamdAudioSamplesAnalyzer(int sampleRateHz)
     {
-        this.pitchEventStream = pitchEventStream;
         halftoneDelays = PrecalculateHalftoneDelays(halftoneFrequencies, sampleRateHz);
     }
 
@@ -57,13 +55,13 @@ public class CamdAudioSamplesAnalyzer : IAudioSamplesAnalyzer
         isEnabled = false;
     }
 
-    public void ProcessAudioSamples(float[] audioSamplesBuffer, int samplesSinceLastFrame, MicProfile mic)
+    public PitchEvent ProcessAudioSamples(float[] audioSamplesBuffer, int samplesSinceLastFrame, MicProfile mic)
     {
         if (!isEnabled || samplesSinceLastFrame < MinSampleLength || lastPitchDetectedFrame == Time.frameCount)
         {
-            return;
+            return null;
         }
-
+        lastPitchDetectedFrame = Time.frameCount;
         int sampleCountToUse = PreviousPowerOfTwo(samplesSinceLastFrame);
 
         // check if samples is louder than threshhold
@@ -80,7 +78,7 @@ public class CamdAudioSamplesAnalyzer : IAudioSamplesAnalyzer
         if (!passesThreshold)
         {
             OnNoPitchDetected();
-            return;
+            return null;
         }
 
         // get best fitting tone
@@ -90,12 +88,15 @@ public class CamdAudioSamplesAnalyzer : IAudioSamplesAnalyzer
         int halftone = CalculateBestFittingHalftone(correlation) + BaseToneMidi + 3;
         if (halftone != -1 && isEnabled)
         {
-            OnPitchDetected(halftone);
+            int midiNoteMedian = GetMidiNoteAverageFromHistory(halftone);
+            if (midiNoteMedian > 0)
+            {
+                return new PitchEvent(midiNoteMedian);
+            }
         }
-        else
-        {
-            OnNoPitchDetected();
-        }
+
+        OnNoPitchDetected();
+        return null;
     }
 
     private static int PreviousPowerOfTwo(int x)
@@ -149,33 +150,31 @@ public class CamdAudioSamplesAnalyzer : IAudioSamplesAnalyzer
         return correlation;
     }
 
-    private void OnPitchDetected(int midiPitch)
+    private int GetMidiNoteAverageFromHistory(int midiNote)
     {
-        lastPitchDetectedFrame = Time.frameCount;
-
         // Create history of PitchRecord events
-        pitchRecordHistory.Add(midiPitch);
-        while (pitchRecordHistoryLength > 0 && pitchRecordHistory.Count > pitchRecordHistoryLength)
-        {
-            pitchRecordHistory.RemoveAt(0);
-        }
+        AddMidiNoteToHistory(midiNote);
 
         // Calculate median of recorded midi note values.
         // This is done to make the pitch detection more stable, but it increases the latency.
         List<int> sortedPitchRecordHistory = new List<int>(pitchRecordHistory);
-        sortedPitchRecordHistory.Sort((pitchRecord1, pitchRecord2) => pitchRecord1.CompareTo(pitchRecord2));
         int midiNoteMedian = sortedPitchRecordHistory[sortedPitchRecordHistory.Count / 2];
 
-        PitchEvent pitchEvent = new PitchEvent(midiNoteMedian);
-        pitchEventStream.OnNext(pitchEvent);
+        return midiNoteMedian;
+    }
+
+    private void AddMidiNoteToHistory(int midiNote)
+    {
+        pitchRecordHistory.Add(midiNote);
+        while (pitchRecordHistoryLength > 0 && pitchRecordHistory.Count > pitchRecordHistoryLength)
+        {
+            pitchRecordHistory.RemoveAt(0);
+        }
     }
 
     private void OnNoPitchDetected()
     {
-        // no tone detected.
-        // Subscribers (such as the PlayerNoteRecorder) must know that the singing ended.
-        // Therefore, a midi pitch of 0 is interpreted as "no singing".
+        // No tone detected.
         pitchRecordHistory.Clear();
-        pitchEventStream.OnNext(new PitchEvent(0));
     }
 }

--- a/UltraStar Play/Assets/Common/Audio/Recording/IAudioSamplesAnalyzer.cs
+++ b/UltraStar Play/Assets/Common/Audio/Recording/IAudioSamplesAnalyzer.cs
@@ -9,5 +9,5 @@ public interface IAudioSamplesAnalyzer
     // However, only the indexes from 0 to (samplesSinceLastFrame - 1) actually contain relevant values.
     // This portion has to be analyzed, samples are in the range from -1 to +1.
     // The rest of the buffer is undefined.
-    void ProcessAudioSamples(float[] audioSamplesBuffer, int samplesSinceLastFrame, MicProfile mic);
+    PitchEvent ProcessAudioSamples(float[] audioSamplesBuffer, int samplesSinceLastFrame, MicProfile mic);
 }

--- a/UltraStar Play/Assets/Common/Audio/Recording/MicrophonePitchTracker.cs
+++ b/UltraStar Play/Assets/Common/Audio/Recording/MicrophonePitchTracker.cs
@@ -13,6 +13,8 @@ public class MicrophonePitchTracker : MonoBehaviour
 
     [ReadOnly]
     public string lastMidiNoteName;
+    [ReadOnly]
+    public int lastMidiNote;
 
     private int micAmplifyMultiplier;
     private MicProfile micProfile;
@@ -59,9 +61,21 @@ public class MicrophonePitchTracker : MonoBehaviour
     void Awake()
     {
         // Update label in inspector for debugging.
-        pitchEventStream.Subscribe(pitchEvent => lastMidiNoteName = (pitchEvent != null)
-                                                                    ? MidiUtils.GetAbsoluteName(pitchEvent.MidiNote)
-                                                                    : "");
+        pitchEventStream.Subscribe(UpdateLastMidiNoteFields);
+    }
+
+    private void UpdateLastMidiNoteFields(PitchEvent pitchEvent)
+    {
+        if (pitchEvent == null)
+        {
+            lastMidiNoteName = "";
+            lastMidiNote = 0;
+        }
+        else
+        {
+            lastMidiNoteName = MidiUtils.GetAbsoluteName(pitchEvent.MidiNote);
+            lastMidiNote = pitchEvent.MidiNote;
+        }
     }
 
     void OnEnable()

--- a/UltraStar Play/Assets/Common/Audio/Recording/MicrophonePitchTracker.cs
+++ b/UltraStar Play/Assets/Common/Audio/Recording/MicrophonePitchTracker.cs
@@ -126,7 +126,7 @@ public class MicrophonePitchTracker : MonoBehaviour
             return;
         }
 
-        Debug.Log($"Stop recording with '{MicProfile}'");
+        Debug.Log($"Stop recording with '{MicProfile.Name}'");
         UnityEngine.Microphone.End(MicProfile.Name);
         startedPitchDetection = false;
     }

--- a/UltraStar Play/Assets/Common/Audio/Recording/MicrophonePitchTracker.cs
+++ b/UltraStar Play/Assets/Common/Audio/Recording/MicrophonePitchTracker.cs
@@ -58,17 +58,16 @@ public class MicrophonePitchTracker : MonoBehaviour
 
     void Awake()
     {
-        audioSamplesAnalyzer = new CamdAudioSamplesAnalyzer(pitchEventStream, SampleRateHz);
-
         // Update label in inspector for debugging.
-        pitchEventStream.Subscribe(pitchEvent => lastMidiNoteName = ((pitchEvent.MidiNote > 0)
+        pitchEventStream.Subscribe(pitchEvent => lastMidiNoteName = (pitchEvent != null)
                                                                     ? MidiUtils.GetAbsoluteName(pitchEvent.MidiNote)
-                                                                    : ""));
+                                                                    : "");
     }
 
     void OnEnable()
     {
         audioSource = GetComponent<AudioSource>();
+        audioSamplesAnalyzer = new CamdAudioSamplesAnalyzer(SampleRateHz);
         audioSamplesAnalyzer.Enable();
     }
 
@@ -168,7 +167,10 @@ public class MicrophonePitchTracker : MonoBehaviour
         ApplyMicAmplification(samplesSinceLastFrame);
 
         // Detect the pitch of the sample.
-        audioSamplesAnalyzer.ProcessAudioSamples(PitchDetectionBuffer, samplesSinceLastFrame, micProfile);
+        PitchEvent pitchEvent = audioSamplesAnalyzer.ProcessAudioSamples(PitchDetectionBuffer, samplesSinceLastFrame, micProfile);
+
+        // Notify listeners
+        pitchEventStream.OnNext(pitchEvent);
     }
 
     private void ApplyMicAmplification(int samplesSinceLastFrame)

--- a/UltraStar Play/Assets/Common/Audio/Recording/PitchEvent.cs
+++ b/UltraStar Play/Assets/Common/Audio/Recording/PitchEvent.cs
@@ -1,4 +1,4 @@
-public struct PitchEvent
+public class PitchEvent
 {
     public int MidiNote { get; set; }
 

--- a/UltraStar Play/Assets/Common/Model/Song/Builder/VoicesBuilder.cs
+++ b/UltraStar Play/Assets/Common/Model/Song/Builder/VoicesBuilder.cs
@@ -233,7 +233,7 @@ public class MutableVoice
             if (lastSentence.EndBeat > sentence.StartBeat)
             {
                 Debug.LogWarning($"Sentence starts before previous sentence is over. Skipping this sentence."
-                + " (last ended on beat {lastSentence.EndBeat}, this should start on beat {sentence.StartBeat})");
+                + $" (last ended on beat {lastSentence.EndBeat}, this should start on beat {sentence.StartBeat})");
             }
             else if (lastSentence.LinebreakBeat > sentence.StartBeat)
             {

--- a/UltraStar Play/Assets/Common/Util/Extensions/ImageExtensions.cs
+++ b/UltraStar Play/Assets/Common/Util/Extensions/ImageExtensions.cs
@@ -1,0 +1,11 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+public static class ImageExtensions
+{
+    public static void SetAlpha(this Image image, float newAlpha)
+    {
+        Color lastColor = image.color;
+        image.color = new Color(lastColor.r, lastColor.g, lastColor.b, newAlpha);
+    }
+}

--- a/UltraStar Play/Assets/Common/Util/Extensions/ImageExtensions.cs.meta
+++ b/UltraStar Play/Assets/Common/Util/Extensions/ImageExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 414cfcd852993ae409b87c4769645edf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UltraStar Play/Assets/Common/Util/Extensions/ListExtensions.cs
+++ b/UltraStar Play/Assets/Common/Util/Extensions/ListExtensions.cs
@@ -4,6 +4,11 @@ using System.Collections.Generic;
 public static class ListExtensions
 {
 
+    public static string ToCsv<T>(this IEnumerable<T> values, string separator = ",", string prefix = "[", string suffix = "]")
+    {
+        return prefix + string.Join(separator, values) + suffix;
+    }
+
     public static void AddIfNotContains<T>(this List<T> list, T item)
     {
         if (!list.Contains(item))

--- a/UltraStar Play/Assets/Common/Util/RectTransformUtils/MoveCornersToAnchorsExtensions.cs
+++ b/UltraStar Play/Assets/Common/Util/RectTransformUtils/MoveCornersToAnchorsExtensions.cs
@@ -4,7 +4,7 @@ public static class MoveCornersToAnchorsExtensions
 {
     public static void MoveCornersToAnchors(this RectTransform rectTransform)
     {
-        rectTransform.sizeDelta = new Vector2(0, 0);
+        rectTransform.sizeDelta = Vector2.zero;
         rectTransform.anchoredPosition = Vector2.zero;
     }
 

--- a/UltraStar Play/Assets/Scenes/Demos/MicrophoneDemo/MicrophoneDemoSceneController.cs
+++ b/UltraStar Play/Assets/Scenes/Demos/MicrophoneDemo/MicrophoneDemoSceneController.cs
@@ -46,7 +46,7 @@ public class MicrophoneDemoSceneController : MonoBehaviour
     private void OnPitchDetected(PitchEvent pitchEvent)
     {
         // Show the note that has been detected
-        if (pitchEvent.MidiNote > 0)
+        if (pitchEvent != null && pitchEvent.MidiNote > 0)
         {
             currentNoteLabel.text = "Note: " + MidiUtils.GetAbsoluteName(pitchEvent.MidiNote);
         }

--- a/UltraStar Play/Assets/Scenes/Options/RecordingOptions/RecordingOptionsMicVisualizer.cs
+++ b/UltraStar Play/Assets/Scenes/Options/RecordingOptions/RecordingOptionsMicVisualizer.cs
@@ -38,7 +38,7 @@ public class RecordingOptionsMicVisualizer : MonoBehaviour
     private void OnPitchDetected(PitchEvent pitchEvent)
     {
         // Show the note that has been detected
-        if (pitchEvent.MidiNote > 0)
+        if (pitchEvent != null && pitchEvent.MidiNote > 0)
         {
             currentNoteLabel.text = "Note: " + MidiUtils.GetAbsoluteName(pitchEvent.MidiNote);
         }

--- a/UltraStar Play/Assets/Scenes/Sing/DummySingers/AbstractDummySinger.cs
+++ b/UltraStar Play/Assets/Scenes/Sing/DummySingers/AbstractDummySinger.cs
@@ -1,25 +1,11 @@
+using System;
 using UnityEngine;
 
 abstract public class AbstractDummySinger : MonoBehaviour
 {
     public int playerIndexToSimulate;
 
-    private SingSceneController singSceneController;
-
-    private PlayerController PlayerController
-    {
-        get
-        {
-            if (singSceneController.PlayerControllers.Count > playerIndexToSimulate)
-            {
-                return singSceneController.PlayerControllers[playerIndexToSimulate];
-            }
-            else
-            {
-                return null;
-            }
-        }
-    }
+    protected PlayerController playerController;
 
     void Awake()
     {
@@ -29,25 +15,12 @@ abstract public class AbstractDummySinger : MonoBehaviour
         }
     }
 
-    void Start()
+    public abstract void UpdateSinging(double currentBeat);
+
+    public void SetPlayerController(PlayerController playerController)
     {
-        singSceneController = SingSceneController.Instance;
+        this.playerController = playerController;
+        // Disable real microphone input for this player
+        playerController.PlayerNoteRecorder.SetMicrophonePitchTrackerEnabled(false);
     }
-
-    void Update()
-    {
-        if (PlayerController == null)
-        {
-            return;
-        }
-
-        // Disable normal pitch detection of the PlayerController
-        PlayerController.PlayerNoteRecorder.SetMicrophonePitchTrackerEnabled(false);
-
-        // Simulate singing
-        double currentBeat = singSceneController.CurrentBeat;
-        UpdateSinging(PlayerController, currentBeat);
-    }
-
-    protected abstract void UpdateSinging(PlayerController playerController, double currentBeat);
 }

--- a/UltraStar Play/Assets/Scenes/Sing/DummySingers/ChangingOffsetSinger.cs
+++ b/UltraStar Play/Assets/Scenes/Sing/DummySingers/ChangingOffsetSinger.cs
@@ -28,7 +28,7 @@ public class ChangingOffsetSinger : AbstractDummySinger
             // (falling flank: now there is no note, but in last frame there was one)
             noteOffset = (noteOffset + 1) % 5;
         }
-        playerController.PlayerNoteRecorder.OnPitchDetected(new PitchEvent(currentMidiNote));
+        playerController.PlayerNoteRecorder.HandlePitchEvent(new PitchEvent(currentMidiNote));
 
         lastNote = noteAtCurrentBeat;
     }

--- a/UltraStar Play/Assets/Scenes/Sing/DummySingers/ChangingOffsetSinger.cs
+++ b/UltraStar Play/Assets/Scenes/Sing/DummySingers/ChangingOffsetSinger.cs
@@ -8,9 +8,9 @@ public class ChangingOffsetSinger : AbstractDummySinger
     private int noteOffset;
     Note lastNote;
 
-    protected override void UpdateSinging(PlayerController playerController, double currentBeat)
+    public override void UpdateSinging(double currentBeat)
     {
-        Sentence currentSentence = playerController.CurrentSentence;
+        Sentence currentSentence = playerController?.CurrentSentence;
         if (currentSentence == null)
         {
             return;

--- a/UltraStar Play/Assets/Scenes/Sing/DummySingers/PerfectSinger.cs
+++ b/UltraStar Play/Assets/Scenes/Sing/DummySingers/PerfectSinger.cs
@@ -6,9 +6,11 @@ using UnityEngine;
 
 public class PerfectSinger : AbstractDummySinger
 {
-    protected override void UpdateSinging(PlayerController playerController, double currentBeat)
+    public int offset = 12;
+
+    public override void UpdateSinging(double currentBeat)
     {
-        Sentence currentSentence = playerController.CurrentSentence;
+        Sentence currentSentence = playerController?.CurrentSentence;
         if (currentSentence == null)
         {
             return;
@@ -18,7 +20,7 @@ public class PerfectSinger : AbstractDummySinger
         Note noteAtCurrentBeat = PlayerNoteRecorder.GetNoteAtBeat(currentSentence, currentBeat);
         if (noteAtCurrentBeat != null)
         {
-            currentMidiNote = noteAtCurrentBeat.MidiNote;
+            currentMidiNote = noteAtCurrentBeat.MidiNote + offset;
         }
         playerController.PlayerNoteRecorder.HandlePitchEvent(new PitchEvent(currentMidiNote));
     }

--- a/UltraStar Play/Assets/Scenes/Sing/DummySingers/PerfectSinger.cs
+++ b/UltraStar Play/Assets/Scenes/Sing/DummySingers/PerfectSinger.cs
@@ -20,6 +20,6 @@ public class PerfectSinger : AbstractDummySinger
         {
             currentMidiNote = noteAtCurrentBeat.MidiNote;
         }
-        playerController.PlayerNoteRecorder.OnPitchDetected(new PitchEvent(currentMidiNote));
+        playerController.PlayerNoteRecorder.HandlePitchEvent(new PitchEvent(currentMidiNote));
     }
 }

--- a/UltraStar Play/Assets/Scenes/Sing/DummySingers/StutterSinger.cs
+++ b/UltraStar Play/Assets/Scenes/Sing/DummySingers/StutterSinger.cs
@@ -4,9 +4,9 @@ using UnityEngine;
 
 public class StutterSinger : AbstractDummySinger
 {
-    protected override void UpdateSinging(PlayerController playerController, double currentBeat)
+    public override void UpdateSinging(double currentBeat)
     {
-        Sentence currentSentence = playerController.CurrentSentence;
+        Sentence currentSentence = playerController?.CurrentSentence;
         if (currentSentence == null)
         {
             return;

--- a/UltraStar Play/Assets/Scenes/Sing/DummySingers/StutterSinger.cs
+++ b/UltraStar Play/Assets/Scenes/Sing/DummySingers/StutterSinger.cs
@@ -22,6 +22,6 @@ public class StutterSinger : AbstractDummySinger
         {
             currentMidiNote = 0;
         }
-        playerController.PlayerNoteRecorder.OnPitchDetected(new PitchEvent(currentMidiNote));
+        playerController.PlayerNoteRecorder.HandlePitchEvent(new PitchEvent(currentMidiNote));
     }
 }

--- a/UltraStar Play/Assets/Scenes/Sing/DummySingers/StutterSinger.cs
+++ b/UltraStar Play/Assets/Scenes/Sing/DummySingers/StutterSinger.cs
@@ -1,0 +1,27 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class StutterSinger : AbstractDummySinger
+{
+    protected override void UpdateSinging(PlayerController playerController, double currentBeat)
+    {
+        Sentence currentSentence = playerController.CurrentSentence;
+        if (currentSentence == null)
+        {
+            return;
+        }
+
+        int currentMidiNote = Random.Range(33, 70);
+        Note noteAtCurrentBeat = PlayerNoteRecorder.GetNoteAtBeat(currentSentence, currentBeat);
+        if (noteAtCurrentBeat != null)
+        {
+            currentMidiNote = noteAtCurrentBeat.MidiNote + Random.Range(-3, 3);
+        }
+        if (Random.Range(0, 5) == 0)
+        {
+            currentMidiNote = 0;
+        }
+        playerController.PlayerNoteRecorder.OnPitchDetected(new PitchEvent(currentMidiNote));
+    }
+}

--- a/UltraStar Play/Assets/Scenes/Sing/DummySingers/StutterSinger.cs.meta
+++ b/UltraStar Play/Assets/Scenes/Sing/DummySingers/StutterSinger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 91fdf6b0f43d1ba459e2dcd59a6ad805
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerController.cs
+++ b/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerController.cs
@@ -176,8 +176,11 @@ public class PlayerController : MonoBehaviour
         {
             return;
         }
+
         Note targetNote = lastRecordedNote.TargetNote;
-        bool isPerfect = ((targetNote.MidiNote == lastRecordedNote.RoundedMidiNote)
+        int targetMidiNoteRelative = MidiUtils.GetRelativePitch(targetNote.MidiNote);
+        int recordedMidiNoteRelative = MidiUtils.GetRelativePitch(lastRecordedNote.RoundedMidiNote);
+        bool isPerfect = ((targetMidiNoteRelative == recordedMidiNoteRelative)
             && (targetNote.StartBeat >= lastRecordedNote.StartBeat)
             && (targetNote.EndBeat <= lastRecordedNote.EndBeat));
         if (isPerfect)

--- a/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerController.cs
+++ b/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerController.cs
@@ -79,11 +79,10 @@ public class PlayerController : MonoBehaviour
         playerUiController.Init(PlayerProfile, MicProfile);
     }
 
-    public void SetPositionInSongInMillis(double positionInSongInMillis)
+    public void SetCurrentBeat(double currentBeat)
     {
         // Change the current sentence, when the current beat is over its last note.
-        double currentBeat = BpmUtils.MillisecondInSongToBeat(SongMeta, positionInSongInMillis);
-        if (CurrentSentence != null && currentBeat > (double)CurrentSentence.EndBeat)
+        if (CurrentSentence != null && currentBeat >= (double)CurrentSentence.EndBeat)
         {
             OnSentenceEnded();
         }
@@ -191,9 +190,10 @@ public class PlayerController : MonoBehaviour
 
     private void OnSentenceEnded()
     {
+        PlayerNoteRecorder.OnSentenceEnded();
         List<RecordedNote> recordedNotes = PlayerNoteRecorder.GetRecordedNotes(CurrentSentence);
         SentenceRating sentenceRating = PlayerScoreController.CalculateScoreForSentence(CurrentSentence, recordedNotes);
-        playerUiController.ShowTotalScore((int)PlayerScoreController.TotalScore);
+        playerUiController.ShowTotalScore(PlayerScoreController.TotalScore);
         if (sentenceRating != null)
         {
             playerUiController.ShowSentenceRating(sentenceRating);

--- a/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerNoteRecorder.cs
+++ b/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerNoteRecorder.cs
@@ -145,13 +145,10 @@ public class PlayerNoteRecorder : MonoBehaviour, IOnHotSwapFinishedListener
             }
 
             // The lastRecordedNote could be ended above, so the following null check is not redundant.
-            if (lastRecordedNote == null)
+            if (lastRecordedNote == null && currentBeat >= nextNoteStartBeat)
             {
-                if (currentBeat >= nextNoteStartBeat)
-                {
-                    // Start singing of a new note
-                    HandleRecordedNoteStarted(pitchEvent.MidiNote, currentBeat);
-                }
+                // Start singing of a new note
+                HandleRecordedNoteStarted(pitchEvent.MidiNote, currentBeat);
             }
         }
     }
@@ -199,15 +196,11 @@ public class PlayerNoteRecorder : MonoBehaviour, IOnHotSwapFinishedListener
         {
             lastRecordedNote.EndBeat = lastRecordedNote.TargetNote.EndBeat;
             playerController.OnRecordedNoteEnded(lastRecordedNote);
+            lastRecordedNote = null;
         }
         else
         {
             playerController.OnRecordedNoteContinued(lastRecordedNote);
-        }
-
-        if (targetNoteIsDone)
-        {
-            lastRecordedNote = null;
         }
     }
 

--- a/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerScoreController.cs
+++ b/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerScoreController.cs
@@ -42,7 +42,7 @@ public class PlayerScoreController : MonoBehaviour
         get
         {
             int targetSentenceCount = (sentenceCount > 20) ? 20 : sentenceCount;
-            double score = MaxPerfectSentenceBonusScore * perfectSentenceCount / targetSentenceCount;
+            double score = (double)MaxPerfectSentenceBonusScore * perfectSentenceCount / targetSentenceCount;
 
             // Round the score up
             score = Math.Ceiling(score);

--- a/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerScoreController.cs
+++ b/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerScoreController.cs
@@ -13,20 +13,58 @@ public class PlayerScoreController : MonoBehaviour
     public static readonly int MaxPerfectSentenceBonusScore = 1000;
     public static readonly int MaxScoreForNotes = MaxScore - MaxPerfectSentenceBonusScore;
 
-    public double TotalScore
+    public int TotalScore
     {
         get
         {
             return NormalNotesTotalScore + GoldenNotesTotalScore + PerfectSentenceBonusTotalScore;
         }
     }
-    public double NormalNotesTotalScore { get; private set; }
-    public double GoldenNotesTotalScore { get; private set; }
-    public double PerfectSentenceBonusTotalScore { get; private set; }
 
-    private double ScoreForCorrectBeatOfNormalNotes { get; set; }
-    private double ScoreForCorrectBeatOfGoldenNotes { get; set; }
-    private double ScoreForPerfectSentence { get; set; }
+    public int NormalNotesTotalScore
+    {
+        get
+        {
+            return (int)(maxScoreForNormalNotes * correctNormalNoteLengthTotal / normalNoteLengthTotal);
+        }
+    }
+
+    public int GoldenNotesTotalScore
+    {
+        get
+        {
+            return (int)(maxScoreForGoldenNotes * correctGoldenNoteLengthTotal / goldenNoteLengthTotal);
+        }
+    }
+
+    public int PerfectSentenceBonusTotalScore
+    {
+        get
+        {
+            int targetSentenceCount = (sentenceCount > 20) ? 20 : sentenceCount;
+            double score = MaxPerfectSentenceBonusScore * perfectSentenceCount / targetSentenceCount;
+
+            // Round the score up
+            score = Math.Ceiling(score);
+            if (score > MaxPerfectSentenceBonusScore)
+            {
+                score = MaxPerfectSentenceBonusScore;
+            }
+            return (int)score;
+        }
+    }
+
+    private int perfectSentenceCount;
+    private int sentenceCount;
+
+    private double maxScoreForNormalNotes;
+    private double maxScoreForGoldenNotes;
+
+    private double normalNoteLengthTotal;
+    private double goldenNoteLengthTotal;
+
+    private double correctNormalNoteLengthTotal;
+    private double correctGoldenNoteLengthTotal;
 
     public void Init(Voice voice)
     {
@@ -46,135 +84,97 @@ public class PlayerScoreController : MonoBehaviour
         }
 
         // Correctly sung notes
-        double correctNormalNoteLength = GetCorrectlySungNoteLength(sentence.NormalNotes, recordedNotes);
-        double correctGoldenNoteLength = GetCorrectlySungNoteLength(sentence.GoldenNotes, recordedNotes);
+        double correctNormalNoteLength = recordedNotes.Select(it => GetCorrectlySungNormalNoteLength(it)).Sum();
+        double correctGoldenNoteLength = recordedNotes.Select(it => GetCorrectlySungGoldenNoteLength(it)).Sum();
         double correctNotesLength = correctNormalNoteLength + correctGoldenNoteLength;
         double totalNotesLength = GetNormalNoteLength(sentence) + GetGoldenNoteLength(sentence);
         double correctNotesPercentage = correctNotesLength / totalNotesLength;
 
-        // Score for notes
-        double scoreForNormalNotes = correctNormalNoteLength * ScoreForCorrectBeatOfNormalNotes;
-        double scoreForGoldenNotes = correctGoldenNoteLength * ScoreForCorrectBeatOfGoldenNotes;
-        NormalNotesTotalScore += scoreForNormalNotes;
-        GoldenNotesTotalScore += scoreForGoldenNotes;
+        // Sum up correctly sung beats
+        correctNormalNoteLengthTotal += (int)correctNormalNoteLength;
+        correctGoldenNoteLengthTotal += (int)correctGoldenNoteLength;
 
         // Score for a perfect sentence
         if (correctNotesPercentage >= SentenceRating.Perfect.PercentageThreshold)
         {
-            PerfectSentenceBonusTotalScore = (PerfectSentenceBonusTotalScore + ScoreForPerfectSentence);
-        }
-        // Not all sentences need to be perfect to achieve the maximum perfect sentence bonus score.
-        // Thus, the limit has to be checked that it does not exceed the maximum.
-        if (PerfectSentenceBonusTotalScore > MaxPerfectSentenceBonusScore)
-        {
-            PerfectSentenceBonusTotalScore = MaxPerfectSentenceBonusScore;
+            perfectSentenceCount++;
         }
 
         SentenceRating sentenceRating = GetSentenceRating(sentence, correctNotesPercentage);
         return sentenceRating;
     }
 
-    private double GetCorrectlySungNoteLength(List<Note> notes, List<RecordedNote> recordedNotes)
+    private int GetCorrectlySungNormalNoteLength(RecordedNote recordedNote)
     {
-        double correctlySungOverlap = 0;
-        foreach (Note note in notes)
+        if (recordedNote.TargetNote == null || !recordedNote.TargetNote.IsNormal)
         {
-            foreach (RecordedNote recordedNote in recordedNotes)
-            {
-                double correctlySungOverlapOfNote = GetCorrectlySungOverlap(note, recordedNote);
-                correctlySungOverlap += correctlySungOverlapOfNote;
-            }
+            return 0;
         }
-        return correctlySungOverlap;
+
+        return GetCorrectlySungNoteLength(recordedNote);
     }
 
-    private double GetCorrectlySungOverlap(Note note, RecordedNote recordedNote)
+    private int GetCorrectlySungGoldenNoteLength(RecordedNote recordedNote)
     {
-        if (note.MidiNote != recordedNote.RoundedMidiNote)
+        if (recordedNote.TargetNote == null || !recordedNote.TargetNote.IsGolden)
         {
             return 0;
         }
 
-        return GetOverlap(note, recordedNote);
+        return GetCorrectlySungNoteLength(recordedNote);
     }
 
-    private double GetOverlap(Note note, RecordedNote recordedNote)
+    private int GetCorrectlySungNoteLength(RecordedNote recordedNote)
     {
-        // No width that could overlap
-        if (recordedNote.StartBeat == recordedNote.EndBeat || note.StartBeat == note.EndBeat)
+        if (recordedNote.TargetNote == null)
         {
             return 0;
         }
 
-        // note: |----|               |----|
-        //  rec:         |--|   |--|
-        if (recordedNote.StartBeat >= note.EndBeat || recordedNote.EndBeat <= note.StartBeat)
+        if (MidiUtils.GetRelativePitch(recordedNote.TargetNote.MidiNote) != MidiUtils.GetRelativePitch(recordedNote.RoundedMidiNote))
         {
             return 0;
         }
 
-        // From here on, there must be some overlap, either inside or half outside.
-        // note: |----|
-        //  rec:  |--| 
-        if (recordedNote.StartBeat >= note.StartBeat && recordedNote.EndBeat <= note.EndBeat)
-        {
-            // RecordedNote completely overlaps
-            return recordedNote.LengthInBeats;
-        }
-
-        // note:    |----|
-        //  rec:  |--| 
-        if (recordedNote.StartBeat <= note.StartBeat)
-        {
-            return recordedNote.EndBeat - note.StartBeat;
-        }
-
-        // note:    |----|
-        //  rec:       |--| 
-        if (recordedNote.EndBeat >= note.EndBeat)
-        {
-            return note.EndBeat - recordedNote.StartBeat;
-        }
-
-        // This should never be reached
-        Debug.LogError("Should never get here. " +
-                        "GetOverlap must have a missing case in its definition " +
-                        $"({note.StartBeat}, {note.EndBeat}) ({recordedNote.StartBeat}, {recordedNote.EndBeat}).");
-        return 0;
+        int correctlySungNoteLength = (int)(recordedNote.EndBeat - recordedNote.StartBeat);
+        return correctlySungNoteLength;
     }
 
     private void UpdateMaxScores(List<Sentence> sentences)
     {
         // Calculate the points for a single beat of a normal or golden note
-        double normalNoteLengthTotal = 0;
-        double goldenNoteLengthTotal = 0;
+        normalNoteLengthTotal = 0;
+        goldenNoteLengthTotal = 0;
         foreach (Sentence sentence in sentences)
         {
             normalNoteLengthTotal += GetNormalNoteLength(sentence);
             goldenNoteLengthTotal += GetGoldenNoteLength(sentence);
         }
 
-        ScoreForCorrectBeatOfNormalNotes = MaxScoreForNotes / (normalNoteLengthTotal + (2 * goldenNoteLengthTotal));
-        ScoreForCorrectBeatOfGoldenNotes = 2 * ScoreForCorrectBeatOfNormalNotes;
+        double scoreForCorrectBeatOfNormalNotes = MaxScoreForNotes / (normalNoteLengthTotal + (2 * goldenNoteLengthTotal));
+        double scoreForCorrectBeatOfGoldenNotes = 2 * scoreForCorrectBeatOfNormalNotes;
+
+        maxScoreForNormalNotes = scoreForCorrectBeatOfNormalNotes * normalNoteLengthTotal;
+        maxScoreForGoldenNotes = scoreForCorrectBeatOfGoldenNotes * goldenNoteLengthTotal;
 
         // Countercheck: The sum of all points must be equal to MaxScoreForNotes
-        double pointsForAllNotes = ScoreForCorrectBeatOfNormalNotes * normalNoteLengthTotal
-                                 + ScoreForCorrectBeatOfGoldenNotes * goldenNoteLengthTotal;
+        double pointsForAllNotes = maxScoreForNormalNotes + maxScoreForGoldenNotes;
         bool isSound = (MaxScoreForNotes == pointsForAllNotes);
         if (!isSound)
         {
             Debug.LogWarning("The definition of scores for normal or golden notes is not sound.");
         }
 
-        // Calculate score for a perfect line.
-        // This is a bonus score of which the maximum amount can be achieved without all sentences beeing perfect.
-        // Thus, there is a minimum value given here.
-        // As a result, the score for perfect sentences has to be checked not to exceed the maximum.
-        ScoreForPerfectSentence = (int)Math.Ceiling((double)MaxPerfectSentenceBonusScore / sentences.Count);
-        if (ScoreForPerfectSentence < 50)
-        {
-            ScoreForPerfectSentence = 50;
-        }
+        // Round the values for the max score of normal / golden notes to avoid floating point inaccuracy.
+        maxScoreForNormalNotes = Math.Ceiling(maxScoreForNormalNotes);
+        maxScoreForGoldenNotes = Math.Ceiling(maxScoreForGoldenNotes);
+        // The sum of the rounded points must not exceed the MaxScoreForNotes.
+        // If the definition is sound then the overhang is at most 2 because of the above rounding.
+        int overhang = (int)(maxScoreForNormalNotes + maxScoreForGoldenNotes) - MaxScoreForNotes;
+        maxScoreForNormalNotes -= overhang;
+
+        // Remember the sentence count to calculate the points for a perfect sentence.
+        sentenceCount = sentences.Count;
     }
 
     private int GetNormalNoteLength(Sentence sentence)

--- a/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerUiController/BeatGridDisplayer.cs
+++ b/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerUiController/BeatGridDisplayer.cs
@@ -1,0 +1,53 @@
+﻿using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class BeatGridDisplayer : MonoBehaviour
+{
+    public RectTransform linePrefab;
+
+    private readonly List<RectTransform> lines = new List<RectTransform>();
+
+    public void DisplaySentence(Sentence sentence)
+    {
+        if (!enabled || sentence == null)
+        {
+            return;
+        }
+
+        RemoveAllLines();
+
+        CreateLines(sentence.StartBeat, sentence.EndBeat);
+    }
+
+    private void RemoveAllLines()
+    {
+        foreach (RectTransform rectTransform in lines)
+        {
+            Destroy(rectTransform.gameObject);
+        }
+        lines.Clear();
+    }
+
+    private void CreateLines(int StartBeat, int EndBeat)
+    {
+        int lengthInBeats = EndBeat - StartBeat;
+
+        for (int i = 0; i <= lengthInBeats; i++)
+        {
+            CreateLine(i, lengthInBeats);
+        }
+    }
+
+    private void CreateLine(int i, int lengthInBeats)
+    {
+        RectTransform line = Instantiate(linePrefab, transform);
+        float x = (float)i / lengthInBeats;
+        line.anchorMin = new Vector2(x, 0);
+        line.anchorMax = new Vector2(x + (2f / 800f), 1);
+        line.MoveCornersToAnchors();
+        line.GetComponent<Image>().SetAlpha(0.25f);
+
+        lines.Add(line);
+    }
+}

--- a/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerUiController/BeatGridDisplayer.cs.meta
+++ b/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerUiController/BeatGridDisplayer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 86c250ee582c29147a3ccecb0cc70cd2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerUiController/CurrentBeatGridDisplayer.cs
+++ b/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerUiController/CurrentBeatGridDisplayer.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+// Draws vertical lines to illustrate where Update is called.
+public class CurrentBeatGridDisplayer : MonoBehaviour
+{
+    public RectTransform linePrefab;
+
+    private readonly List<RectTransform> lines = new List<RectTransform>();
+
+    private SingSceneController singSceneController;
+    private Sentence currentSentence;
+
+    public void DisplaySentence(Sentence sentence)
+    {
+        currentSentence = sentence;
+        RemoveAllLines();
+    }
+
+    void Awake()
+    {
+        singSceneController = FindObjectOfType<SingSceneController>();
+    }
+
+    void Update()
+    {
+        // This script is only for debugging
+        if (!Application.isEditor)
+        {
+            gameObject.SetActive(false);
+            return;
+        }
+
+        if (currentSentence == null)
+        {
+            return;
+        }
+
+        double currentBeat = singSceneController.CurrentBeat;
+        CreateLine(currentBeat, currentSentence.StartBeat, currentSentence.EndBeat);
+    }
+
+    private void RemoveAllLines()
+    {
+        foreach (RectTransform rectTransform in lines)
+        {
+            Destroy(rectTransform.gameObject);
+        }
+        lines.Clear();
+    }
+
+    private void CreateLine(double currentBeat, int sentenceStartBeat, int sentenceEndBeat)
+    {
+        float x = (float)(currentBeat - sentenceStartBeat) / (sentenceEndBeat - sentenceStartBeat);
+        RectTransform line = Instantiate(linePrefab, transform);
+        line.anchorMin = new Vector2(x, 0);
+        line.anchorMax = new Vector2(x + (2f / 800f), 0.1f);
+        line.MoveCornersToAnchors();
+        line.GetComponent<Image>().color = Color.red;
+        line.GetComponent<Image>().SetAlpha(0.5f);
+
+        lines.Add(line);
+    }
+}

--- a/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerUiController/CurrentBeatGridDisplayer.cs.meta
+++ b/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerUiController/CurrentBeatGridDisplayer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 961f75d94b70d5548890ca20c21f59aa
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerUiController/PlayerUi.prefab
+++ b/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerUiController/PlayerUi.prefab
@@ -28,7 +28,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1740204221501400868}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -534,6 +534,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 641890770593803178}
+  - {fileID: 3176150518743041249}
   - {fileID: 8867538048539712728}
   - {fileID: 5214595654765679579}
   - {fileID: 2587138191213194081}
@@ -598,7 +599,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1740204221501400868}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -681,6 +682,56 @@ MonoBehaviour:
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
   m_LayoutPriority: 1
+--- !u!1 &3032861032120942048
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3176150518743041249}
+  - component: {fileID: 3258929227482826764}
+  m_Layer: 5
+  m_Name: CurrentBeatGridDisplayer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3176150518743041249
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3032861032120942048}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1740204221501400868}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &3258929227482826764
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3032861032120942048}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 961f75d94b70d5548890ca20c21f59aa, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  linePrefab: {fileID: 1194152596973659647, guid: 0e44a1330a41aac458b12308c1a1ddfa,
+    type: 3}
 --- !u!1 &3749304209800659016
 GameObject:
   m_ObjectHideFlags: 0
@@ -709,7 +760,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1740204221501400868}
-  m_RootOrder: 4
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -933,7 +984,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1740204221501400868}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}

--- a/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerUiController/PlayerUi.prefab
+++ b/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerUiController/PlayerUi.prefab
@@ -28,7 +28,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1740204221501400868}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -533,6 +533,7 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
+  - {fileID: 641890770593803178}
   - {fileID: 8867538048539712728}
   - {fileID: 5214595654765679579}
   - {fileID: 2587138191213194081}
@@ -566,7 +567,7 @@ MonoBehaviour:
   uiNotesContainer: {fileID: 5214595654765679579}
   uiRecordedNotesContainer: {fileID: 2587138191213194081}
   uiEffectsContainer: {fileID: 5977041234652890053}
-  displayRoundedAndActualRecordedNotes: 1
+  displayRoundedAndActualRecordedNotes: 0
   showPitchOfNotes: 0
   showLyricsOfNotes: 1
 --- !u!1 &2434205905051527726
@@ -597,7 +598,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1740204221501400868}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -708,13 +709,63 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1740204221501400868}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &4532277260887202835
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 641890770593803178}
+  - component: {fileID: 5185930075616471766}
+  m_Layer: 5
+  m_Name: BeatGridDisplayer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &641890770593803178
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4532277260887202835}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1740204221501400868}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &5185930075616471766
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4532277260887202835}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 86c250ee582c29147a3ccecb0cc70cd2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  linePrefab: {fileID: 1194152596973659647, guid: 0e44a1330a41aac458b12308c1a1ddfa,
+    type: 3}
 --- !u!1 &6798354893538703529
 GameObject:
   m_ObjectHideFlags: 0
@@ -882,10 +933,10 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1740204221501400868}
-  m_RootOrder: 0
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: -0.0047650463, y: 0}
-  m_AnchorMax: {x: 1.0050391, y: 1}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}

--- a/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerUiController/PlayerUiController.cs
+++ b/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerUiController/PlayerUiController.cs
@@ -10,6 +10,7 @@ public class PlayerUiController : MonoBehaviour
     private SentenceDisplayer sentenceDisplayer;
     private TotalScoreDisplayer totalScoreDisplayer;
     private SentenceRatingDisplayer sentenceRatingDisplayer;
+    private BeatGridDisplayer beatGridDisplayer;
 
     public void Init(PlayerProfile playerProfile, MicProfile micProfile)
     {
@@ -22,6 +23,8 @@ public class PlayerUiController : MonoBehaviour
         totalScoreDisplayer = GetComponentInChildren<TotalScoreDisplayer>();
 
         sentenceRatingDisplayer = GetComponentInChildren<SentenceRatingDisplayer>();
+
+        beatGridDisplayer = GetComponentInChildren<BeatGridDisplayer>();
 
         PlayerNameText playerNameText = GetComponentInChildren<PlayerNameText>();
         playerNameText.SetPlayerProfile(playerProfile);
@@ -39,6 +42,7 @@ public class PlayerUiController : MonoBehaviour
     public void DisplaySentence(Sentence currentSentence)
     {
         sentenceDisplayer.DisplaySentence(currentSentence);
+        beatGridDisplayer?.DisplaySentence(currentSentence);
     }
 
     public void RemoveAllDisplayedNotes()

--- a/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerUiController/PlayerUiController.cs
+++ b/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerUiController/PlayerUiController.cs
@@ -11,6 +11,7 @@ public class PlayerUiController : MonoBehaviour
     private TotalScoreDisplayer totalScoreDisplayer;
     private SentenceRatingDisplayer sentenceRatingDisplayer;
     private BeatGridDisplayer beatGridDisplayer;
+    private CurrentBeatGridDisplayer currentBeatGridDisplayer;
 
     public void Init(PlayerProfile playerProfile, MicProfile micProfile)
     {
@@ -25,6 +26,8 @@ public class PlayerUiController : MonoBehaviour
         sentenceRatingDisplayer = GetComponentInChildren<SentenceRatingDisplayer>();
 
         beatGridDisplayer = GetComponentInChildren<BeatGridDisplayer>();
+
+        currentBeatGridDisplayer = GetComponentInChildren<CurrentBeatGridDisplayer>();
 
         PlayerNameText playerNameText = GetComponentInChildren<PlayerNameText>();
         playerNameText.SetPlayerProfile(playerProfile);
@@ -43,6 +46,7 @@ public class PlayerUiController : MonoBehaviour
     {
         sentenceDisplayer.DisplaySentence(currentSentence);
         beatGridDisplayer?.DisplaySentence(currentSentence);
+        currentBeatGridDisplayer?.DisplaySentence(currentSentence);
     }
 
     public void RemoveAllDisplayedNotes()

--- a/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerUiController/SentenceDisplayer.cs
+++ b/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerUiController/SentenceDisplayer.cs
@@ -95,8 +95,7 @@ public class SentenceDisplayer : MonoBehaviour
 
     private void CreateUiNote(Note note)
     {
-        UiNote uiNote = Instantiate(uiNotePrefab);
-        uiNote.transform.SetParent(uiNotesContainer);
+        UiNote uiNote = Instantiate(uiNotePrefab, uiNotesContainer);
         uiNote.Init(note, uiEffectsContainer);
         if (micProfile != null)
         {
@@ -139,8 +138,7 @@ public class SentenceDisplayer : MonoBehaviour
     {
         int midiNote = (useRoundedMidiNote) ? recordedNote.RoundedMidiNote : recordedNote.RecordedMidiNote;
 
-        UiRecordedNote uiNote = Instantiate(uiRecordedNotePrefab);
-        uiNote.transform.SetParent(uiRecordedNotesContainer);
+        UiRecordedNote uiNote = Instantiate(uiRecordedNotePrefab, uiRecordedNotesContainer);
         if (micProfile != null)
         {
             uiNote.SetColorOfMicProfile(micProfile);
@@ -174,15 +172,14 @@ public class SentenceDisplayer : MonoBehaviour
         int sentenceEndBeat = displayedSentence.EndBeat;
         int beatsInSentence = sentenceEndBeat - sentenceStartBeat;
 
-        double anchorY = (double)noteLine / (double)noteLineCount;
-        double anchorX = (double)(noteStartBeat - sentenceStartBeat) / beatsInSentence;
-        Vector2 anchor = new Vector2((float)anchorX, (float)anchorY);
-        uiNote.anchorMin = anchor;
-        uiNote.anchorMax = anchor;
-        uiNote.anchoredPosition = Vector2.zero;
+        float anchorY = (float)noteLine / noteLineCount;
+        float anchorXStart = (float)(noteStartBeat - sentenceStartBeat) / beatsInSentence;
+        float anchorXEnd = (float)(noteEndBeat - sentenceStartBeat) / beatsInSentence;
 
-        float length = (float)(noteEndBeat - noteStartBeat);
-        uiNote.sizeDelta = new Vector2(800f * length / (float)beatsInSentence, uiNote.sizeDelta.y);
+        uiNote.anchorMin = new Vector2(anchorXStart, anchorY);
+        uiNote.anchorMax = new Vector2(anchorXEnd, anchorY);
+        uiNote.MoveCornersToAnchors_Width();
+        uiNote.MoveCornersToAnchors_CenterPosition();
     }
 
     public void CreatePerfectSentenceEffect()

--- a/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerUiController/SentenceDisplayer.cs
+++ b/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerUiController/SentenceDisplayer.cs
@@ -95,6 +95,11 @@ public class SentenceDisplayer : MonoBehaviour
 
     private void CreateUiNote(Note note)
     {
+        if (note.StartBeat == note.EndBeat)
+        {
+            return;
+        }
+
         UiNote uiNote = Instantiate(uiNotePrefab, uiNotesContainer);
         uiNote.Init(note, uiEffectsContainer);
         if (micProfile != null)
@@ -136,6 +141,11 @@ public class SentenceDisplayer : MonoBehaviour
 
     private void CreateUiRecordedNote(RecordedNote recordedNote, bool useRoundedMidiNote)
     {
+        if (recordedNote.StartBeat == recordedNote.EndBeat)
+        {
+            return;
+        }
+
         int midiNote = (useRoundedMidiNote) ? recordedNote.RoundedMidiNote : recordedNote.RecordedMidiNote;
 
         UiRecordedNote uiNote = Instantiate(uiRecordedNotePrefab, uiRecordedNotesContainer);
@@ -157,7 +167,6 @@ public class SentenceDisplayer : MonoBehaviour
 
         RectTransform uiNoteRectTransform = uiNote.GetComponent<RectTransform>();
         PositionUiNote(uiNoteRectTransform, midiNote, recordedNote.StartBeat, recordedNote.EndBeat);
-
         recordedNoteToUiRecordedNoteMap[recordedNote] = uiNote;
     }
 

--- a/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerUiController/SentenceRankingPopup.prefab
+++ b/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerUiController/SentenceRankingPopup.prefab
@@ -116,7 +116,7 @@ RectTransform:
   m_AnchorMin: {x: 1, y: 0.5}
   m_AnchorMax: {x: 1, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 115, y: 40}
+  m_SizeDelta: {x: 115, y: 30}
   m_Pivot: {x: 1, y: 0.5}
 --- !u!222 &8270118676613553341
 CanvasRenderer:

--- a/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerUiController/SentenceRatingDisplayer.cs
+++ b/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerUiController/SentenceRatingDisplayer.cs
@@ -10,7 +10,6 @@ public class SentenceRatingDisplayer : MonoBehaviour
     public void ShowSentenceRating(SentenceRating sentenceRating)
     {
         SentenceRatingPopup sentenceRatingPopup = Instantiate(sentenceRatingPopupPrefab, transform);
-        sentenceRatingPopup.GetComponent<RectTransform>().MoveCornersToAnchors();
         sentenceRatingPopup.SetSentenceRating(sentenceRating);
     }
 }

--- a/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerUiController/UiNotePrefab.prefab
+++ b/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerUiController/UiNotePrefab.prefab
@@ -32,11 +32,11 @@ RectTransform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -30, y: 0}
-  m_SizeDelta: {x: 60, y: 25}
-  m_Pivot: {x: 0, y: 0.5}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 25}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2444222340775961529
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerUiController/UiNotePrefab.prefab
+++ b/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerUiController/UiNotePrefab.prefab
@@ -35,7 +35,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 1, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 25}
+  m_SizeDelta: {x: 0, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2444222340775961529
 MonoBehaviour:

--- a/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerUiController/UiRecordedNote.cs
+++ b/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerUiController/UiRecordedNote.cs
@@ -5,7 +5,7 @@ using UnityEngine.UI;
 
 public class UiRecordedNote : MonoBehaviour
 {
-    public float colorFactor = 0.7f;
+    public float colorFactor = 0.6f;
 
     private Image image;
 

--- a/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerUiController/UiRecordedNotePrefab.prefab
+++ b/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerUiController/UiRecordedNotePrefab.prefab
@@ -32,11 +32,11 @@ RectTransform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -30, y: 0}
-  m_SizeDelta: {x: 60, y: 25}
-  m_Pivot: {x: 0, y: 0.5}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2003371037910514456
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UltraStar Play/Assets/Scenes/Sing/PlayerController/RecordedNote.cs
+++ b/UltraStar Play/Assets/Scenes/Sing/PlayerController/RecordedNote.cs
@@ -13,6 +13,7 @@ public class RecordedNote
     public double StartBeat { get; set; }
     public double EndBeat { get; set; }
 
+    public Sentence Sentence { get; set; }
     public Note TargetNote { get; set; }
 
     public RecordedNote(int midiNote, double startBeat, double endBeat)

--- a/UltraStar Play/Assets/Scenes/Sing/SingScene.unity
+++ b/UltraStar Play/Assets/Scenes/Sing/SingScene.unity
@@ -487,9 +487,9 @@ MonoBehaviour:
   anchorMin: {x: 0.5, y: 0.1}
   anchorMax: {x: 0.5, y: 1}
   pivot: {x: 0.5, y: 0.5}
-  localPosition: {x: 0, y: 1.6096449, z: 0}
+  localPosition: {x: 0, y: 1.4678564, z: 0}
   sizeDelta: {x: 2, y: 0}
-  size: {x: 2, y: 28.974703}
+  size: {x: 2, y: 26.42251}
 --- !u!1 &320770002
 GameObject:
   m_ObjectHideFlags: 0
@@ -612,9 +612,9 @@ MonoBehaviour:
   anchorMin: {x: 0, y: 0}
   anchorMax: {x: 0, y: 0}
   pivot: {x: 0.5, y: 0.5}
-  localPosition: {x: 515.5, y: 293.5, z: 0}
-  sizeDelta: {x: 799.99994, y: 455.4801}
-  size: {x: 799.99994, y: 455.4801}
+  localPosition: {x: 448.5, y: 233, z: 0}
+  sizeDelta: {x: 800, y: 415.60757}
+  size: {x: 800, y: 415.60757}
 --- !u!1 &475691986
 GameObject:
   m_ObjectHideFlags: 0
@@ -863,7 +863,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!114 &727012071
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1508,7 +1508,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0c11810cb9527c047beda7fd4b488be2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultSongName: Summer Wine
+  defaultSongName: EmptyTitle
   defaultSongNamePasteBin: 'Summer Wine
 
     EmptyTitle

--- a/UltraStar Play/Assets/Scenes/Sing/SingScene.unity
+++ b/UltraStar Play/Assets/Scenes/Sing/SingScene.unity
@@ -863,7 +863,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!114 &727012071
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/UltraStar Play/Assets/Scenes/Sing/SingScene.unity
+++ b/UltraStar Play/Assets/Scenes/Sing/SingScene.unity
@@ -1049,6 +1049,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   playerIndexToSimulate: 0
+  offset: 12
 --- !u!4 &908260464
 Transform:
   m_ObjectHideFlags: 0

--- a/UltraStar Play/Assets/Scenes/Sing/SingScene.unity
+++ b/UltraStar Play/Assets/Scenes/Sing/SingScene.unity
@@ -487,9 +487,9 @@ MonoBehaviour:
   anchorMin: {x: 0.5, y: 0.1}
   anchorMax: {x: 0.5, y: 1}
   pivot: {x: 0.5, y: 0.5}
-  localPosition: {x: 0, y: 1.4678564, z: 0}
+  localPosition: {x: 0, y: 1.604126, z: 0}
   sizeDelta: {x: 2, y: 0}
-  size: {x: 2, y: 26.42251}
+  size: {x: 2, y: 28.875366}
 --- !u!1 &320770002
 GameObject:
   m_ObjectHideFlags: 0
@@ -612,9 +612,9 @@ MonoBehaviour:
   anchorMin: {x: 0, y: 0}
   anchorMax: {x: 0, y: 0}
   pivot: {x: 0.5, y: 0.5}
-  localPosition: {x: 448.5, y: 233, z: 0}
-  sizeDelta: {x: 800, y: 415.60757}
-  size: {x: 800, y: 415.60757}
+  localPosition: {x: 515.5, y: 292.5, z: 0}
+  sizeDelta: {x: 799.99994, y: 453.9282}
+  size: {x: 799.99994, y: 453.9282}
 --- !u!1 &475691986
 GameObject:
   m_ObjectHideFlags: 0
@@ -1508,7 +1508,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0c11810cb9527c047beda7fd4b488be2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultSongName: EmptyTitle
+  defaultSongName: Summer Wine
   defaultSongNamePasteBin: 'Summer Wine
 
     EmptyTitle

--- a/UltraStar Play/Assets/Scenes/Sing/SingScene.unity
+++ b/UltraStar Play/Assets/Scenes/Sing/SingScene.unity
@@ -847,6 +847,50 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   timeLineRectPrefab: {fileID: 2269057298797317534, guid: cfe0e826bda13d04c9d90a045027b253,
     type: 3}
+--- !u!1 &727012070
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 727012072}
+  - component: {fileID: 727012071}
+  m_Layer: 0
+  m_Name: StutterSinger
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!114 &727012071
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 727012070}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 91fdf6b0f43d1ba459e2dcd59a6ad805, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  playerIndexToSimulate: 0
+--- !u!4 &727012072
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 727012070}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 509.63995, y: 300.0832, z: -547.75}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!224 &746576793 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 1740204220683369330, guid: e2db2cdfcd84c1d4fbe3e38bae31b2ba,

--- a/UltraStar Play/Assets/Scenes/Sing/SingScene.unity
+++ b/UltraStar Play/Assets/Scenes/Sing/SingScene.unity
@@ -889,7 +889,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 6
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!224 &746576793 stripped
 RectTransform:
@@ -976,6 +976,49 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 774528932}
   m_CullTransparentMesh: 0
+--- !u!1 &898766839
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 898766841}
+  - component: {fileID: 898766840}
+  m_Layer: 0
+  m_Name: SingSceneFinisher
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &898766840
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 898766839}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 232574d4ef532f84898091ca8b1bc0fd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &898766841
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 898766839}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 496.1132, y: 296.42233, z: -282.25}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &908260462
 GameObject:
   m_ObjectHideFlags: 0
@@ -1018,7 +1061,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 4
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &992840886
 GameObject:
@@ -1396,7 +1439,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 5
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1343510743
 GameObject:

--- a/UltraStar Play/Assets/Scenes/Sing/SingSceneController.cs
+++ b/UltraStar Play/Assets/Scenes/Sing/SingSceneController.cs
@@ -286,24 +286,6 @@ public class SingSceneController : MonoBehaviour, IOnHotSwapFinishedListener
         SceneNavigator.Instance.LoadScene(EScene.SongEditorScene, songEditorSceneData);
     }
 
-    private void CheckSongFinished()
-    {
-        if (audioPlayer.clip == null || DurationOfSongInMillis == 0)
-        {
-            return;
-        }
-
-        double missingMillis = DurationOfSongInMillis - PositionInSongInMillis;
-        if (missingMillis <= 0)
-        {
-            Invoke("FinishScene", 1f);
-        }
-        else
-        {
-            Invoke("CheckSongFinished", (float)(missingMillis / 1000.0));
-        }
-    }
-
     public void FinishScene()
     {
         // Open the singing results scene.
@@ -558,9 +540,6 @@ public class SingSceneController : MonoBehaviour, IOnHotSwapFinishedListener
                 // The time bar needs the duration of the song to calculate positions.
                 // The duration of the song should be available now.
                 InitTimeBar();
-
-                // Go to next scene when the song finishes
-                CheckSongFinished();
             }
         }
 

--- a/UltraStar Play/Assets/Scenes/Sing/SingSceneController.cs
+++ b/UltraStar Play/Assets/Scenes/Sing/SingSceneController.cs
@@ -114,7 +114,8 @@ public class SingSceneController : MonoBehaviour, IOnHotSwapFinishedListener
             {
                 return 0;
             }
-            return (audioPlayer.clip.samples / audioPlayer.clip.frequency) * 1000.0f;
+            double lengthInMillis = 1000.0 * audioPlayer.clip.samples / audioPlayer.clip.frequency;
+            return lengthInMillis;
 
         }
     }

--- a/UltraStar Play/Assets/Scenes/Sing/SingSceneFinisher.cs
+++ b/UltraStar Play/Assets/Scenes/Sing/SingSceneFinisher.cs
@@ -1,0 +1,73 @@
+using System;
+using UnityEngine;
+
+// Handles automatically finishing the SingScene.
+// The Unity AudioPlayer changes the playback position back to zero when the AudioClip has finished.
+// This script detects this falling flank in the playback position
+// and will finish the scene with a small delay afterwards.
+// To prevent premature ending the scene, it is only watched for the falling flank in the playback position
+// when the song has been near its end already.
+public class SingSceneFinisher : MonoBehaviour
+{
+    private bool hasBeenNearEndOfSong;
+    private bool isSongFinished;
+    private float durationAfterSongFinishedInSeconds;
+
+    private SingSceneController singSceneController;
+
+    private double positionInSongInMillisOld;
+
+    void Awake()
+    {
+        singSceneController = FindObjectOfType<SingSceneController>();
+    }
+
+    void Update()
+    {
+        double durationOfSongInMillis = singSceneController.DurationOfSongInMillis;
+        if (durationOfSongInMillis <= 0)
+        {
+            return;
+        }
+
+        if (isSongFinished)
+        {
+            durationAfterSongFinishedInSeconds += Time.deltaTime;
+            if (durationAfterSongFinishedInSeconds >= 1)
+            {
+                singSceneController.FinishScene();
+            }
+        }
+        else
+        {
+            double positionInSongInMillis = singSceneController.PositionInSongInMillis;
+
+            // Normal detection of song finished.
+            // This only works when the position is not reset to zero when the AudioClip finishes.
+            if (Math.Abs(durationOfSongInMillis - positionInSongInMillis) <= 1)
+            {
+                isSongFinished = true;
+            }
+
+            // Detection of the end of the song by looking for a falling flank in the position in the song.
+            if (hasBeenNearEndOfSong)
+            {
+                // The position is back to the start.
+                if (positionInSongInMillis < 1000 && positionInSongInMillis < positionInSongInMillisOld)
+                {
+                    isSongFinished = true;
+                }
+                positionInSongInMillisOld = positionInSongInMillis;
+            }
+            else
+            {
+                // The position is near the end of the song.
+                double missingMillis = durationOfSongInMillis - positionInSongInMillis;
+                if (missingMillis < 1000)
+                {
+                    hasBeenNearEndOfSong = true;
+                }
+            }
+        }
+    }
+}

--- a/UltraStar Play/Assets/Scenes/Sing/SingSceneFinisher.cs.meta
+++ b/UltraStar Play/Assets/Scenes/Sing/SingSceneFinisher.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 232574d4ef532f84898091ca8b1bc0fd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UltraStar Play/Assets/Scenes/SingingResults/SingingResultsSceneKeyboardController.cs
+++ b/UltraStar Play/Assets/Scenes/SingingResults/SingingResultsSceneKeyboardController.cs
@@ -5,12 +5,10 @@ using UnityEngine;
 public class SingingResultsSceneKeyboardController : MonoBehaviour
 {
 
-    private const KeyCode ContinueToNextSceneShortcut = KeyCode.Return;
-    private const KeyCode ContinueToNextSceneShortcut2 = KeyCode.Escape;
-
     void Update()
     {
-        if (Input.GetKeyUp(ContinueToNextSceneShortcut) || Input.GetKeyUp(ContinueToNextSceneShortcut2))
+        if (Input.GetKeyUp(KeyCode.Return) || Input.GetKeyUp(KeyCode.Escape) || Input.GetKeyUp(KeyCode.Space)
+            || Input.GetMouseButtonUp(0) || Input.GetMouseButtonUp(1))
         {
             SingingResultsSceneController.Instance.FinishScene();
         }

--- a/UltraStar Play/ProjectSettings/AudioManager.asset
+++ b/UltraStar Play/ProjectSettings/AudioManager.asset
@@ -9,11 +9,11 @@ AudioManager:
   Doppler Factor: 1
   Default Speaker Mode: 2
   m_SampleRate: 0
-  m_DSPBufferSize: 256
+  m_DSPBufferSize: 1024
   m_VirtualVoiceCount: 512
   m_RealVoiceCount: 32
   m_SpatializerPlugin: 
   m_AmbisonicDecoderPlugin: 
   m_DisableAudio: 0
   m_VirtualizeEffects: 1
-  m_RequestedDSPBufferSize: 256
+  m_RequestedDSPBufferSize: 1024


### PR DESCRIPTION
Sorry for all the changes. This grew bigger and bigger because I always found new bugs and edge cases and needed the previous fixes to work it out.

### What does this PR do?

This one fixes issues with drawing notes, recording notes, giving points, finishing the sing scene and maybe few others.

I added a GridBeatDisplayer which is nice to see where beats are in the song.
Similarly, CurrentBeatGridDisplayer shows where Update is called. This is useful to see where beats are skipped.

Recording notes and giving points is now done per beat.
Player scores do not have a floating point inaccuracy issue anymore. If you sing perfect, you get 10000 points.

I changed the IAudioSamplesAnalyzer a bit: ProcessAudio now returns a PitchEvent, and the PitchEvent can be null. So there is no pitchEventStream given to the IAudioSamplesAnalyzer, and no 0 midi note is emitted as "no pitch".

There was also an issue where perfectly sung notes were not recognized, because I was not comparing the relative pitches of notes.

I also noticed that PositionInSongInMillis was changing during the same frame (i.e. different Update calls in the same frame). This makes comparing these values difficult and things can get weird. So now I calculate this value only once per frame.

