### PR TITLE
corrected pitch detection

### DIFF
--- a/UltraStar Play/Assets/Common/Audio/MidiUtils.cs
+++ b/UltraStar Play/Assets/Common/Audio/MidiUtils.cs
@@ -1,9 +1,15 @@
 using System;
-using System.Collections;
-using System.Collections.Generic;
 
 public static class MidiUtils
 {
+    // There are 49 halftones in the singable audio spectrum,
+    // namely C2 (midi note 36, which is 65.41 Hz) to C6 (midi note 84, which is 1046.5023 Hz).
+    public const int MidiNoteMin = 36;
+    public const int MidiNoteMax = 84;
+
+    // Concert pitch A4 (440 Hz)
+    public const int MidiNoteConcertPitch = 69;
+    public const int MidiNoteConcertPitchFrequency = 440;
 
     public static int GetOctave(int midiNote)
     {

--- a/UltraStar Play/Assets/Common/Audio/Recording/CamdAudioSamplesAnalyzer.cs
+++ b/UltraStar Play/Assets/Common/Audio/Recording/CamdAudioSamplesAnalyzer.cs
@@ -1,15 +1,12 @@
 using System;
 using System.Collections.Generic;
-using UniRx;
 using UnityEngine;
 
 public class CamdAudioSamplesAnalyzer : IAudioSamplesAnalyzer
 {
-    /** There are 49 halftones in the singable audio spectrum (C2 to C6 (1046.5023 Hz)). */
-    private const int NumHalftones = 49;
-    /** A4 concert pitch of 440 Hz. */
-    private const float BaseToneFreq = 440f;
-    private const int BaseToneMidi = 33;
+    // The singable spectrum of a human voice has about 4 octaves (C2 to C6).
+    // +1 here, because if min and max are equal, then you are still able to sing one note.
+    private const int NumHalftones = (MidiUtils.MidiNoteMax - MidiUtils.MidiNoteMin) + 1;
     private const int MinSampleLength = 256;
     private static readonly double[] halftoneFrequencies = PrecalculateHalftoneFrequencies();
 
@@ -30,7 +27,8 @@ public class CamdAudioSamplesAnalyzer : IAudioSamplesAnalyzer
         double[] noteFrequencies = new double[NumHalftones];
         for (int index = 0; index < NumHalftones; index++)
         {
-            noteFrequencies[index] = BaseToneFreq * Math.Pow(2f, (index - BaseToneMidi) / 12f);
+            float concertPitchOctaveOffset = ((MidiUtils.MidiNoteMin + index) - MidiUtils.MidiNoteConcertPitch) / 12f;
+            noteFrequencies[index] = MidiUtils.MidiNoteConcertPitchFrequency * Math.Pow(2f, concertPitchOctaveOffset);
         }
         return noteFrequencies;
     }
@@ -87,8 +85,7 @@ public class CamdAudioSamplesAnalyzer : IAudioSamplesAnalyzer
         int halftone = CalculateBestFittingHalftone(correlation);
         if (halftone != -1 && isEnabled)
         {
-            // no idea where the +3 is coming from...
-            int midiNoteMedian = GetMidiNoteAverageFromHistory(halftone + BaseToneMidi + 3);
+            int midiNoteMedian = GetMidiNoteAverageFromHistory(halftone + MidiUtils.MidiNoteMin);
             if (midiNoteMedian > 0)
             {
                 return new PitchEvent(midiNoteMedian);


### PR DESCRIPTION
### What does this PR do?

Fix pitch detection parameters, namely frequencies and lowest singable note.

I found where the mysterious + 3 was coming from. The midi note of C2 (lowest singable voice) is 36 not 33.
Furthermore, there was an issue in the calculation of the frequencies. The octave offset was not correct.

You can find a good comparison of midi note, piano key, frequency, and note name (english and german) here: https://www.inspiredacoustics.com/en/MIDI_note_numbers_and_center_frequencies

I tested my changes with my guitar tuner and 440 Hz sine wave generated in Audacity. The pitch detection is correct now.