### PR TITLE
Anst/editor shortcuts

### DIFF
--- a/UltraStar Play/Assets/Common/Scene/CommonSceneObjectsBinder.cs
+++ b/UltraStar Play/Assets/Common/Scene/CommonSceneObjectsBinder.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using UniInject;
 using UnityEngine;
+using UnityEngine.EventSystems;
 
 public class CommonSceneObjectsBinder : MonoBehaviour, IBinder
 {
@@ -14,6 +15,9 @@ public class CommonSceneObjectsBinder : MonoBehaviour, IBinder
         bb.BindExistingInstance(ThemeManager.Instance);
         bb.BindExistingInstance(CursorManager.Instance);
         bb.BindExistingInstance(UiManager.Instance);
+
+        EventSystem eventSystem = GameObjectUtils.FindComponentWithTag<EventSystem>("EventSystem");
+        bb.BindExistingInstance(eventSystem);
 
         // Lazy binding of settings, because they are not needed in every scene and loading the settings takes time.
         bb.BindExistingInstanceLazy(() => SettingsManager.Instance.Settings);

--- a/UltraStar Play/Assets/Common/Util/GameObjectUtils.cs
+++ b/UltraStar Play/Assets/Common/Util/GameObjectUtils.cs
@@ -4,17 +4,16 @@ using System.Linq;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.SceneManagement;
+using UnityEngine.UI;
 
 public static class GameObjectUtils
 {
-
-    /// Returns the currentSelectedGameObject from the EventSystem.
-    /// Normally, this is the UI control that has the focus (e.g. a Button, InputField or Toggle).
-    public static GameObject GetSelectedGameObject()
+    /// Returns true if there is a selected GameObject and it has a Component of type InputField
+    /// The EventSystem is one of the CommonSceneObjects that can be injected.
+    public static bool InputFieldHasFocus(EventSystem eventSystem)
     {
-        EventSystem eventSystem = GameObjectUtils.FindComponentWithTag<EventSystem>("EventSystem");
-        GameObject result = eventSystem.currentSelectedGameObject;
-        return result;
+        GameObject selectedGameObject = eventSystem.currentSelectedGameObject;
+        return selectedGameObject != null && selectedGameObject.GetComponentInChildren<InputField>() != null;
     }
 
     /// Looks in the GameObject with the given tag

--- a/UltraStar Play/Assets/Scenes/SongEditor/SongEditorCopyPasteManager.cs
+++ b/UltraStar Play/Assets/Scenes/SongEditor/SongEditorCopyPasteManager.cs
@@ -6,6 +6,7 @@ using UnityEngine;
 using UnityEngine.UI;
 using UniInject;
 using UniRx;
+using UnityEngine.EventSystems;
 
 // Disable warning about fields that are never assigned, their values are injected.
 #pragma warning disable CS0649
@@ -30,6 +31,9 @@ public class SongEditorCopyPasteManager : MonoBehaviour, INeedInjection
     [Inject]
     private SongMetaChangeEventStream songMetaChangeEventStream;
 
+    [Inject]
+    private EventSystem eventSystem;
+
     private Voice copiedVoice;
 
     private List<Note> CopiedNotes
@@ -47,24 +51,23 @@ public class SongEditorCopyPasteManager : MonoBehaviour, INeedInjection
 
     void Update()
     {
+        if (GameObjectUtils.InputFieldHasFocus(eventSystem))
+        {
+            return;
+        }
+
         EKeyboardModifier modifier = InputUtils.GetCurrentKeyboardModifier();
         if (modifier == EKeyboardModifier.Ctrl)
         {
-            if (Input.GetKeyUp(KeyCode.C) && !InputFieldHasFocus())
+            if (Input.GetKeyUp(KeyCode.C))
             {
                 CopySelectedNotes();
             }
-            else if (Input.GetKeyUp(KeyCode.V) && !InputFieldHasFocus())
+            else if (Input.GetKeyUp(KeyCode.V))
             {
                 PasteCopiedNotes();
             }
         }
-    }
-
-    private bool InputFieldHasFocus()
-    {
-        GameObject selectedGameObject = GameObjectUtils.GetSelectedGameObject();
-        return selectedGameObject != null && selectedGameObject.GetComponentInChildren<InputField>() != null;
     }
 
     private void MoveCopiedNotesToMillisInSong(double newMillis)

--- a/UltraStar Play/Assets/Scenes/SongEditor/SongEditorSceneKeyboardController.cs
+++ b/UltraStar Play/Assets/Scenes/SongEditor/SongEditorSceneKeyboardController.cs
@@ -157,6 +157,29 @@ public class SongEditorSceneKeyboardController : MonoBehaviour, INeedInjection
             noteArea.ScrollHorizontal(1);
         }
 
+        // Zoom horizontal with Ctrl+'+' and Ctrl+'-'
+        // Note: On my keyboard, the plus button has KeyCode.Equals but I don't know why.
+        bool isPlusKeyUp = Input.GetKeyUp(KeyCode.Plus) || Input.GetKeyUp(KeyCode.KeypadPlus) || Input.GetKeyUp(KeyCode.Equals);
+        bool isMinusKeyUp = Input.GetKeyUp(KeyCode.Minus) || Input.GetKeyUp(KeyCode.KeypadMinus);
+        if (isPlusKeyUp && modifier == EKeyboardModifier.Ctrl)
+        {
+            noteArea.ZoomHorizontal(1);
+        }
+        if (isMinusKeyUp && modifier == EKeyboardModifier.Ctrl)
+        {
+            noteArea.ZoomHorizontal(-1);
+        }
+
+        // Zoom vertical with Ctrl+Shift+'+' and Ctrl+Shift+'-'
+        if (isPlusKeyUp && modifier == EKeyboardModifier.CtrlShift)
+        {
+            noteArea.ZoomVertical(1);
+        }
+        if (isMinusKeyUp && modifier == EKeyboardModifier.CtrlShift)
+        {
+            noteArea.ZoomVertical(-1);
+        }
+
         // Zoom and scroll with mouse wheel
         int scrollDirection = Math.Sign(Input.mouseScrollDelta.y);
         if (scrollDirection != 0 && noteArea.IsPointerOver)

--- a/UltraStar Play/Assets/Scenes/SongEditor/SongEditorSceneKeyboardController.cs
+++ b/UltraStar Play/Assets/Scenes/SongEditor/SongEditorSceneKeyboardController.cs
@@ -54,6 +54,12 @@ public class SongEditorSceneKeyboardController : MonoBehaviour, INeedInjection
             songAudioPlayer.PauseAudio();
         }
 
+        // Select all notes via Ctrl+A
+        if (Input.GetKeyUp(KeyCode.A) && modifier == EKeyboardModifier.Ctrl)
+        {
+            selectionController.SelectAll();
+        }
+
         // Delete notes
         if (Input.GetKeyUp(KeyCode.Delete))
         {

--- a/UltraStar Play/Assets/Scenes/SongEditor/SongEditorSceneKeyboardController.cs
+++ b/UltraStar Play/Assets/Scenes/SongEditor/SongEditorSceneKeyboardController.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using UniInject;
 using UnityEngine;
+using UnityEngine.EventSystems;
 using UnityEngine.UI;
 
 #pragma warning disable CS0649
@@ -38,12 +39,20 @@ public class SongEditorSceneKeyboardController : MonoBehaviour, INeedInjection
     [Inject]
     private SongAudioPlayer songAudioPlayer;
 
+    [Inject]
+    private EventSystem eventSystem;
+
     public void Update()
     {
+        if (GameObjectUtils.InputFieldHasFocus(eventSystem))
+        {
+            return;
+        }
+
         EKeyboardModifier modifier = InputUtils.GetCurrentKeyboardModifier();
 
         // Play / pause via Space
-        if (Input.GetKeyUp(KeyCode.Space) && !InputFieldHasFocus())
+        if (Input.GetKeyUp(KeyCode.Space))
         {
             ToggleAudioPlayPause();
         }
@@ -116,11 +125,11 @@ public class SongEditorSceneKeyboardController : MonoBehaviour, INeedInjection
         // Change position in song with Ctrl+ArrowKey
         if (!songAudioPlayer.IsPlaying)
         {
-            if (Input.GetKey(KeyCode.LeftArrow) && modifier == EKeyboardModifier.Ctrl && !InputFieldHasFocus())
+            if (Input.GetKey(KeyCode.LeftArrow) && modifier == EKeyboardModifier.Ctrl)
             {
                 songAudioPlayer.PositionInSongInMillis -= 1;
             }
-            if (Input.GetKey(KeyCode.RightArrow) && modifier == EKeyboardModifier.Ctrl && !InputFieldHasFocus())
+            if (Input.GetKey(KeyCode.RightArrow) && modifier == EKeyboardModifier.Ctrl)
             {
                 songAudioPlayer.PositionInSongInMillis += 1;
             }
@@ -131,12 +140,6 @@ public class SongEditorSceneKeyboardController : MonoBehaviour, INeedInjection
 
         // Scroll and zoom in NoteArea
         UpdateInputToScrollAndZoom(modifier);
-    }
-
-    private bool InputFieldHasFocus()
-    {
-        GameObject selectedGameObject = GameObjectUtils.GetSelectedGameObject();
-        return selectedGameObject != null && selectedGameObject.GetComponentInChildren<InputField>() != null;
     }
 
     private void ToggleAudioPlayPause()
@@ -154,11 +157,11 @@ public class SongEditorSceneKeyboardController : MonoBehaviour, INeedInjection
     private void UpdateInputToScrollAndZoom(EKeyboardModifier modifier)
     {
         // Scroll with arroy keys
-        if (Input.GetKeyUp(KeyCode.LeftArrow) && modifier == EKeyboardModifier.None && !InputFieldHasFocus())
+        if (Input.GetKeyUp(KeyCode.LeftArrow) && modifier == EKeyboardModifier.None)
         {
             noteArea.ScrollHorizontal(-1);
         }
-        if (Input.GetKeyUp(KeyCode.RightArrow) && modifier == EKeyboardModifier.None && !InputFieldHasFocus())
+        if (Input.GetKeyUp(KeyCode.RightArrow) && modifier == EKeyboardModifier.None)
         {
             noteArea.ScrollHorizontal(1);
         }
@@ -230,6 +233,11 @@ public class SongEditorSceneKeyboardController : MonoBehaviour, INeedInjection
             return;
         }
 
+        if (modifier == EKeyboardModifier.None)
+        {
+            return;
+        }
+
         foreach (Note note in selectedNotes)
         {
             // Move with Shift
@@ -237,6 +245,12 @@ public class SongEditorSceneKeyboardController : MonoBehaviour, INeedInjection
             {
                 note.MoveHorizontal((int)arrowKeyDirection.x);
                 note.MoveVertical((int)arrowKeyDirection.y);
+            }
+
+            // Move notes one octave up / down via Ctrl+Shift
+            if (modifier == EKeyboardModifier.CtrlShift)
+            {
+                note.MoveVertical((int)arrowKeyDirection.y * 12);
             }
 
             // Extend right side with Alt

--- a/UltraStar Play/Assets/Scenes/SongEditor/SongEditorSelectionController.cs
+++ b/UltraStar Play/Assets/Scenes/SongEditor/SongEditorSelectionController.cs
@@ -43,6 +43,12 @@ public class SongEditorSelectionController : MonoBehaviour, INeedInjection
         selectedNotes.Clear();
     }
 
+    public void SelectAll()
+    {
+        List<Note> allNotes = songEditorSceneController.GetAllNotes();
+        SetSelection(allNotes);
+    }
+
     public void AddToSelection(List<EditorUiNote> uiNotes)
     {
         foreach (EditorUiNote uiNote in uiNotes)

--- a/UltraStar Play/Assets/Scenes/SongSelect/SongSelectScene.unity
+++ b/UltraStar Play/Assets/Scenes/SongSelect/SongSelectScene.unity
@@ -2046,37 +2046,37 @@ PrefabInstance:
     - target: {fileID: 3622033094347370610, guid: 176e869a9ab83ce4aa378e24fe6fb891,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: -26
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3622033094347370610, guid: 176e869a9ab83ce4aa378e24fe6fb891,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 243.23
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3622033094347370610, guid: 176e869a9ab83ce4aa378e24fe6fb891,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: -51.9
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3622033094347370610, guid: 176e869a9ab83ce4aa378e24fe6fb891,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: -486.45
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3622033094347370610, guid: 176e869a9ab83ce4aa378e24fe6fb891,
         type: 3}
       propertyPath: m_AnchorMin.x
-      value: 0
+      value: -0.000061109684
       objectReference: {fileID: 0}
     - target: {fileID: 3622033094347370610, guid: 176e869a9ab83ce4aa378e24fe6fb891,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 0.8565121
       objectReference: {fileID: 0}
     - target: {fileID: 3622033094347370610, guid: 176e869a9ab83ce4aa378e24fe6fb891,
         type: 3}
       propertyPath: m_AnchorMax.x
-      value: 1
+      value: 0.9365688
       objectReference: {fileID: 0}
     - target: {fileID: 3622033094347370610, guid: 176e869a9ab83ce4aa378e24fe6fb891,
         type: 3}

--- a/UltraStar Play/Assets/Scenes/SongSelect/SongSelectSceneKeyboardInputController.cs
+++ b/UltraStar Play/Assets/Scenes/SongSelect/SongSelectSceneKeyboardInputController.cs
@@ -2,8 +2,12 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UniInject;
+using UnityEngine.EventSystems;
 
-public class SongSelectSceneKeyboardInputController : MonoBehaviour
+#pragma warning disable CS0649
+
+public class SongSelectSceneKeyboardInputController : MonoBehaviour, INeedInjection
 {
     private const KeyCode NextSongShortcut = KeyCode.RightArrow;
     private const KeyCode PreviousSongShortcut = KeyCode.LeftArrow;
@@ -13,6 +17,9 @@ public class SongSelectSceneKeyboardInputController : MonoBehaviour
 
     private const KeyCode QuickSearchSong = KeyCode.LeftControl;
     private const KeyCode QuickSearchArtist = KeyCode.LeftAlt;
+
+    [Inject]
+    private EventSystem eventSystem;
 
     void Update()
     {
@@ -62,7 +69,7 @@ public class SongSelectSceneKeyboardInputController : MonoBehaviour
         if (Input.GetKeyUp(StartSingSceneShortcut)
             || (Input.GetKeyUp(OpenInEditorShortcut) && !songSelectSceneController.IsSearchEnabled()))
         {
-            GameObject focusedControl = GameObjectUtils.GetSelectedGameObject();
+            GameObject focusedControl = eventSystem.currentSelectedGameObject;
             bool focusedControlIsSongButton = (focusedControl != null && focusedControl.GetComponent<SongRouletteItem>() != null);
             bool focusedControlIsSearchField = (focusedControl != null && focusedControl.GetComponent<SearchInputField>() != null);
             if (focusedControl == null || focusedControlIsSongButton || focusedControlIsSearchField)


### PR DESCRIPTION
### What does this PR do?

Add shortcuts for the song editor:
- Zoom via Ctrl+'+' and Ctrl+'-'
- Select all via Ctrl+A
- Move notes one octave up / down via Ctrl+Shift+ArrowUp / Ctrl+Shift+ArrowDown

Also a small refactoring. The EventSystem (a CommonSceneObject) can be injected and is used to check whether an InputField has the focus.
