### PR TITLE
song editor - make golden, freestyle, normal shortcuts

### DIFF
--- a/UltraStar Play/Assets/Common/Util/InputUtils.cs
+++ b/UltraStar Play/Assets/Common/Util/InputUtils.cs
@@ -38,4 +38,26 @@ public static class InputUtils
         }
         return EKeyboardModifier.None;
     }
+
+    public static Vector2 GetArrowKeyDirection()
+    {
+        Vector2 result = Vector2.zero;
+        if (Input.GetKeyUp(KeyCode.LeftArrow))
+        {
+            result += new Vector2(-1, 0);
+        }
+        if (Input.GetKeyUp(KeyCode.RightArrow))
+        {
+            result += new Vector2(1, 0);
+        }
+        if (Input.GetKeyUp(KeyCode.UpArrow))
+        {
+            result += new Vector2(0, 1);
+        }
+        if (Input.GetKeyUp(KeyCode.DownArrow))
+        {
+            result += new Vector2(0, -1);
+        }
+        return result;
+    }
 }

--- a/UltraStar Play/Assets/Plugins/UniInject/Injector.cs
+++ b/UltraStar Play/Assets/Plugins/UniInject/Injector.cs
@@ -266,7 +266,7 @@ namespace UniInject
                     valueToBeInjected = GetValueForInjectionKey(injectionKey);
                 }
 
-                valuesToBeInjected[index] = valueToBeInjected ?? throw new InjectionException($"Value to be injected for key {injectionKey} is null");
+                valuesToBeInjected[index] = valueToBeInjected ?? throw new MissingBindingException($"Value to be injected for key {injectionKey} is null");
                 index++;
             }
             return valuesToBeInjected;

--- a/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerNoteRecorder.cs
+++ b/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerNoteRecorder.cs
@@ -24,7 +24,7 @@ public class PlayerNoteRecorder : MonoBehaviour, INeedInjection, IInjectionFinis
     [Inject]
     private PlayerProfile playerProfile;
 
-    [Inject]
+    [Inject(optional = true)]
     private MicProfile micProfile;
 
     [Inject(searchMethod = SearchMethods.GetComponentInChildren)]

--- a/UltraStar Play/Assets/Scenes/SongEditor/Actions/ExtendNotesAction.cs
+++ b/UltraStar Play/Assets/Scenes/SongEditor/Actions/ExtendNotesAction.cs
@@ -1,0 +1,51 @@
+using System.Collections.Generic;
+using UniInject;
+
+// Disable warning about fields that are never assigned, their values are injected.
+#pragma warning disable CS0649
+
+public class ExtendNotesAction : INeedInjection
+{
+    [Inject]
+    private SongMetaChangeEventStream songMetaChangeEventStream;
+
+    public void ExtendNotesLeft(int distanceInBeats, IEnumerable<Note> selectedNotes)
+    {
+        foreach (Note note in selectedNotes)
+        {
+            int newStartBeat = note.StartBeat + distanceInBeats;
+            if (newStartBeat < note.EndBeat)
+            {
+                note.SetStartBeat(newStartBeat);
+            }
+        }
+    }
+
+    public void ExtendNotesRight(int distanceInBeats, IEnumerable<Note> selectedNotes, IEnumerable<Note> followingNotes)
+    {
+        foreach (Note note in selectedNotes)
+        {
+            int newEndBeat = note.EndBeat + distanceInBeats;
+            if (newEndBeat > note.StartBeat)
+            {
+                note.SetEndBeat(newEndBeat);
+            }
+        }
+        foreach (Note note in followingNotes)
+        {
+            note.MoveHorizontal(distanceInBeats);
+        }
+    }
+
+    public void ExtendNotesLeftAndNotify(int distanceInBeats, IEnumerable<Note> selectedNotes)
+    {
+        ExtendNotesLeft(distanceInBeats, selectedNotes);
+        songMetaChangeEventStream.OnNext(new NotesChangedEvent());
+    }
+
+    public void ExtendNotesRightAndNotify(int distanceInBeats, IEnumerable<Note> selectedNotes, IEnumerable<Note> followingNotes)
+    {
+        ExtendNotesRight(distanceInBeats, selectedNotes, followingNotes);
+        songMetaChangeEventStream.OnNext(new NotesChangedEvent());
+    }
+}

--- a/UltraStar Play/Assets/Scenes/SongEditor/Actions/ExtendNotesAction.cs.meta
+++ b/UltraStar Play/Assets/Scenes/SongEditor/Actions/ExtendNotesAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9264b4b27bdb2584c9c6786d584567e6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UltraStar Play/Assets/Scenes/SongEditor/Actions/MoveNotesAction.cs
+++ b/UltraStar Play/Assets/Scenes/SongEditor/Actions/MoveNotesAction.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using System.Linq;
+using UniInject;
+
+// Disable warning about fields that are never assigned, their values are injected.
+#pragma warning disable CS0649
+
+public class MoveNotesAction : INeedInjection
+{
+    [Inject]
+    private SongMetaChangeEventStream songMetaChangeEventStream;
+
+    public void MoveNotesHorizontal(int distanceInBeats, IEnumerable<Note> selectedNotes, IEnumerable<Note> followingNotes)
+    {
+        foreach (Note note in selectedNotes.Union(followingNotes))
+        {
+            note.MoveHorizontal(distanceInBeats);
+        }
+    }
+
+    public void MoveNotesVertical(int distanceInMidiNotes, IEnumerable<Note> selectedNotes, IEnumerable<Note> followingNotes)
+    {
+        foreach (Note note in selectedNotes.Union(followingNotes))
+        {
+            note.MoveVertical(distanceInMidiNotes);
+        }
+    }
+
+    public void MoveNotesVerticalAndNotify(int distanceInMidiNotes, IEnumerable<Note> selectedNotes, IEnumerable<Note> followingNotes)
+    {
+        MoveNotesVertical(distanceInMidiNotes, selectedNotes, followingNotes);
+        songMetaChangeEventStream.OnNext(new NotesChangedEvent());
+    }
+
+    public void MoveNotesHorizontalAndNotify(int distanceInBeats, IEnumerable<Note> selectedNotes, IEnumerable<Note> followingNotes)
+    {
+        MoveNotesHorizontal(distanceInBeats, selectedNotes, followingNotes);
+        songMetaChangeEventStream.OnNext(new NotesChangedEvent());
+    }
+}

--- a/UltraStar Play/Assets/Scenes/SongEditor/Actions/MoveNotesAction.cs.meta
+++ b/UltraStar Play/Assets/Scenes/SongEditor/Actions/MoveNotesAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7a9cc97fc4819f34097170164d55876e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UltraStar Play/Assets/Scenes/SongEditor/Actions/SongEditorActionBinder.cs
+++ b/UltraStar Play/Assets/Scenes/SongEditor/Actions/SongEditorActionBinder.cs
@@ -17,6 +17,8 @@ public class SongEditorActionBinder : MonoBehaviour, IBinder
         bb.BindTypeToNewInstances(typeof(AddNoteAction));
         bb.BindTypeToNewInstances(typeof(MoveNoteToAjacentSentenceAction));
         bb.BindTypeToNewInstances(typeof(MoveNotesToOtherVoiceAction));
+        bb.BindTypeToNewInstances(typeof(MoveNotesAction));
+        bb.BindTypeToNewInstances(typeof(ExtendNotesAction));
 
         bb.BindTypeToNewInstances(typeof(ToggleNoteTypeAction));
 

--- a/UltraStar Play/Assets/Scenes/SongEditor/Actions/SongEditorActionBinder.cs
+++ b/UltraStar Play/Assets/Scenes/SongEditor/Actions/SongEditorActionBinder.cs
@@ -18,6 +18,8 @@ public class SongEditorActionBinder : MonoBehaviour, IBinder
         bb.BindTypeToNewInstances(typeof(MoveNoteToAjacentSentenceAction));
         bb.BindTypeToNewInstances(typeof(MoveNotesToOtherVoiceAction));
 
+        bb.BindTypeToNewInstances(typeof(ToggleNoteTypeAction));
+
         bb.BindTypeToNewInstances(typeof(DeleteSentencesAction));
         bb.BindTypeToNewInstances(typeof(MergeSentencesAction));
         bb.BindTypeToNewInstances(typeof(SentenceFitToNoteAction));

--- a/UltraStar Play/Assets/Scenes/SongEditor/Actions/ToggleNoteTypeAction.cs
+++ b/UltraStar Play/Assets/Scenes/SongEditor/Actions/ToggleNoteTypeAction.cs
@@ -9,7 +9,7 @@ public class ToggleNoteTypeAction : INeedInjection
     [Inject]
     private SongMetaChangeEventStream songMetaChangeEventStream;
 
-    public void Execute(IReadOnlyCollection<Note> selectedNotes, ENoteType noteType)
+    public void Execute(IEnumerable<Note> selectedNotes, ENoteType noteType)
     {
         bool allHaveNoteType = selectedNotes.AllMatch(it => it.Type == noteType);
         ENoteType targetNoteType = (allHaveNoteType) ? ENoteType.Normal : noteType;
@@ -19,7 +19,7 @@ public class ToggleNoteTypeAction : INeedInjection
         }
     }
 
-    public void ExecuteAndNotify(IReadOnlyCollection<Note> selectedNotes, ENoteType noteType)
+    public void ExecuteAndNotify(IEnumerable<Note> selectedNotes, ENoteType noteType)
     {
         Execute(selectedNotes, noteType);
         songMetaChangeEventStream.OnNext(new NoteTypeChangeEvent());

--- a/UltraStar Play/Assets/Scenes/SongEditor/Actions/ToggleNoteTypeAction.cs
+++ b/UltraStar Play/Assets/Scenes/SongEditor/Actions/ToggleNoteTypeAction.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using UniInject;
+
+// Disable warning about fields that are never assigned, their values are injected.
+#pragma warning disable CS0649
+
+public class ToggleNoteTypeAction : INeedInjection
+{
+    [Inject]
+    private SongMetaChangeEventStream songMetaChangeEventStream;
+
+    public void Execute(IReadOnlyCollection<Note> selectedNotes, ENoteType noteType)
+    {
+        bool allHaveNoteType = selectedNotes.AllMatch(it => it.Type == noteType);
+        ENoteType targetNoteType = (allHaveNoteType) ? ENoteType.Normal : noteType;
+        foreach (Note note in selectedNotes)
+        {
+            note.SetType(targetNoteType);
+        }
+    }
+
+    public void ExecuteAndNotify(IReadOnlyCollection<Note> selectedNotes, ENoteType noteType)
+    {
+        Execute(selectedNotes, noteType);
+        songMetaChangeEventStream.OnNext(new NoteTypeChangeEvent());
+    }
+}

--- a/UltraStar Play/Assets/Scenes/SongEditor/Actions/ToggleNoteTypeAction.cs.meta
+++ b/UltraStar Play/Assets/Scenes/SongEditor/Actions/ToggleNoteTypeAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e569afbccef91a64389ad0aa858a811c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UltraStar Play/Assets/Scenes/SongEditor/EditorNote/EditorNoteContextMenuHandler.cs
+++ b/UltraStar Play/Assets/Scenes/SongEditor/EditorNote/EditorNoteContextMenuHandler.cs
@@ -106,6 +106,16 @@ public class EditorNoteContextMenuHandler : AbstractContextMenuHandler, INeedInj
             contextMenu.AddItem("Make freestyle",
                 () => setNoteTypeAction.ExecuteAndNotify(selectedNotes, ENoteType.Freestyle));
         }
+        if (setNoteTypeAction.CanExecute(selectedNotes, ENoteType.Rap))
+        {
+            contextMenu.AddItem("Make rap",
+                () => setNoteTypeAction.ExecuteAndNotify(selectedNotes, ENoteType.Rap));
+        }
+        if (setNoteTypeAction.CanExecute(selectedNotes, ENoteType.RapGolden))
+        {
+            contextMenu.AddItem("Make rap-golden",
+                () => setNoteTypeAction.ExecuteAndNotify(selectedNotes, ENoteType.RapGolden));
+        }
         if (setNoteTypeAction.CanExecute(selectedNotes, ENoteType.Normal))
         {
             contextMenu.AddItem("Make normal",

--- a/UltraStar Play/Assets/Scenes/SongEditor/EditorNote/EditorUiNote.cs
+++ b/UltraStar Play/Assets/Scenes/SongEditor/EditorNote/EditorUiNote.cs
@@ -228,7 +228,11 @@ public class EditorUiNote : MonoBehaviour, IPointerClickHandler, IPointerEnterHa
     {
         if (Note.IsFreestyle)
         {
-            uiText.text = $"<i>{newText}</i>";
+            uiText.text = $"<i><b><color=#800000>{newText}</color></b></i>";
+        }
+        else if (Note.IsGolden)
+        {
+            uiText.text = $"<b>{newText}</b>";
         }
         else
         {

--- a/UltraStar Play/Assets/Scenes/SongEditor/EditorNote/EditorUiNote.cs
+++ b/UltraStar Play/Assets/Scenes/SongEditor/EditorNote/EditorUiNote.cs
@@ -226,17 +226,21 @@ public class EditorUiNote : MonoBehaviour, IPointerClickHandler, IPointerEnterHa
 
     public void SetText(string newText)
     {
-        if (Note.IsFreestyle)
+        switch (Note.Type)
         {
-            uiText.text = $"<i><b><color=#800000>{newText}</color></b></i>";
-        }
-        else if (Note.IsGolden)
-        {
-            uiText.text = $"<b>{newText}</b>";
-        }
-        else
-        {
-            uiText.text = newText;
+            case ENoteType.Freestyle:
+                uiText.text = $"<i><b><color=#c00000>{newText}</color></b></i>";
+                break;
+            case ENoteType.Golden:
+                uiText.text = $"<b>{newText}</b>";
+                break;
+            case ENoteType.Rap:
+            case ENoteType.RapGolden:
+                uiText.text = $"<i><b><color=#ffa500ff>{newText}</color></b></i>";
+                break;
+            default:
+                uiText.text = newText;
+                break;
         }
     }
 

--- a/UltraStar Play/Assets/Scenes/SongEditor/Issues/EditorUiIssueDisplayer.cs
+++ b/UltraStar Play/Assets/Scenes/SongEditor/Issues/EditorUiIssueDisplayer.cs
@@ -37,9 +37,15 @@ public class EditorUiIssueDisplayer : MonoBehaviour, INeedInjection, ISceneInjec
     private ViewportEvent lastViewportEvent;
     private float lastSongMetaBpm;
 
+    public void OnSceneInjectionFinished()
+    {
+        songMetaChangeEventStream.Subscribe(OnSongMetaChanged);
+    }
+
     void Start()
     {
         issuePrefabWidthInPixels = issuePrefab.GetComponent<RectTransform>().rect.width;
+
         UpdateIssues();
 
         noteArea.ViewportEventStream.Subscribe(OnViewportChanged);
@@ -58,11 +64,6 @@ public class EditorUiIssueDisplayer : MonoBehaviour, INeedInjection, ISceneInjec
         lastViewportEvent = viewportEvent;
     }
 
-    public void OnSceneInjectionFinished()
-    {
-        songMetaChangeEventStream.Subscribe(OnSongMetaChanged);
-    }
-
     private void OnSongMetaChanged(ISongMetaChangeEvent changeEvent)
     {
         if (changeEvent is LyricsChangedEvent)
@@ -70,11 +71,16 @@ public class EditorUiIssueDisplayer : MonoBehaviour, INeedInjection, ISceneInjec
             return;
         }
 
-        issues = SongMetaAnalyzer.AnalyzeIssues(songMeta);
         UpdateIssues();
     }
 
     private void UpdateIssues()
+    {
+        issues = SongMetaAnalyzer.AnalyzeIssues(songMeta);
+        DrawIssues();
+    }
+
+    private void DrawIssues()
     {
         uiIssueContainer.DestroyAllDirectChildren();
 

--- a/UltraStar Play/Assets/Scenes/SongEditor/NoteArea/NoteArea.cs
+++ b/UltraStar Play/Assets/Scenes/SongEditor/NoteArea/NoteArea.cs
@@ -83,6 +83,7 @@ public class NoteArea : MonoBehaviour, INeedInjection, IPointerEnterHandler, IPo
         SetViewport(x, y, width, height);
 
         songAudioPlayer.PositionInSongEventStream.Subscribe(SetPositionInSongInMillis);
+        SetPositionInSongInMillis(songAudioPlayer.PositionInSongInMillis);
 
         songMetaChangeEventStream.Subscribe(OnSongMetaChanged);
 

--- a/UltraStar Play/Assets/Scenes/SongEditor/SongEditorSceneKeyboardController.cs
+++ b/UltraStar Play/Assets/Scenes/SongEditor/SongEditorSceneKeyboardController.cs
@@ -200,6 +200,14 @@ public class SongEditorSceneKeyboardController : MonoBehaviour, INeedInjection
         {
             toggleNoteTypeAction.ExecuteAndNotify(selectionController.GetSelectedNotes(), ENoteType.Normal);
         }
+        if (Input.GetKeyUp(KeyCode.R))
+        {
+            toggleNoteTypeAction.ExecuteAndNotify(selectionController.GetSelectedNotes(), ENoteType.Rap);
+        }
+        if (Input.GetKeyUp(KeyCode.T))
+        {
+            toggleNoteTypeAction.ExecuteAndNotify(selectionController.GetSelectedNotes(), ENoteType.RapGolden);
+        }
     }
 
     // Implements keyboard shortcuts similar to Yass.

--- a/UltraStar Play/Assets/Scenes/SongEditor/SongEditorSceneKeyboardController.cs
+++ b/UltraStar Play/Assets/Scenes/SongEditor/SongEditorSceneKeyboardController.cs
@@ -42,6 +42,9 @@ public class SongEditorSceneKeyboardController : MonoBehaviour, INeedInjection
     [Inject]
     private EventSystem eventSystem;
 
+    [Inject]
+    private ToggleNoteTypeAction toggleNoteTypeAction;
+
     // Unity does not provide Input.anyKeyUp, only Input.anyKey, and Input.anyKeyDown.
     private bool isAnyKey;
     private bool isAnyKeyUp;
@@ -181,29 +184,16 @@ public class SongEditorSceneKeyboardController : MonoBehaviour, INeedInjection
 
         if (Input.GetKeyUp(KeyCode.G))
         {
-            ToggleNoteType(ENoteType.Golden);
+            toggleNoteTypeAction.ExecuteAndNotify(selectionController.GetSelectedNotes(), ENoteType.Golden);
         }
         if (Input.GetKeyUp(KeyCode.F))
         {
-            ToggleNoteType(ENoteType.Freestyle);
+            toggleNoteTypeAction.ExecuteAndNotify(selectionController.GetSelectedNotes(), ENoteType.Freestyle);
         }
         if (Input.GetKeyUp(KeyCode.N))
         {
-            ToggleNoteType(ENoteType.Normal);
+            toggleNoteTypeAction.ExecuteAndNotify(selectionController.GetSelectedNotes(), ENoteType.Normal);
         }
-    }
-
-    private void ToggleNoteType(ENoteType noteType)
-    {
-        List<Note> selectedNotes = selectionController.GetSelectedNotes();
-        bool allHaveNoteType = selectedNotes.AllMatch(it => it.Type == noteType);
-        ENoteType targetNoteType = (allHaveNoteType) ? ENoteType.Normal : noteType;
-        foreach (Note note in selectedNotes)
-        {
-            note.SetType(targetNoteType);
-        }
-
-        editorNoteDisplayer.UpdateNotesAndSentences();
     }
 
     // Implements keyboard shortcuts similar to Yass.

--- a/UltraStar Play/Assets/Scenes/SongEditor/SongEditorSceneKeyboardController.cs
+++ b/UltraStar Play/Assets/Scenes/SongEditor/SongEditorSceneKeyboardController.cs
@@ -159,6 +159,9 @@ public class SongEditorSceneKeyboardController : MonoBehaviour, INeedInjection
             }
         }
 
+        // Make golden / freestyle / normal
+        UpdateInputToChangeNoteType(modifier);
+
         // Move and stretch notes
         UpdateInputToMoveAndStretchNotes(modifier);
 
@@ -167,6 +170,40 @@ public class SongEditorSceneKeyboardController : MonoBehaviour, INeedInjection
 
         // Use the shortcuts that are also used in the YASS song editor.
         UpdateInputForYassShortcuts(modifier);
+    }
+
+    private void UpdateInputToChangeNoteType(EKeyboardModifier modifier)
+    {
+        if (modifier != EKeyboardModifier.None)
+        {
+            return;
+        }
+
+        if (Input.GetKeyUp(KeyCode.G))
+        {
+            ToggleNoteType(ENoteType.Golden);
+        }
+        if (Input.GetKeyUp(KeyCode.F))
+        {
+            ToggleNoteType(ENoteType.Freestyle);
+        }
+        if (Input.GetKeyUp(KeyCode.N))
+        {
+            ToggleNoteType(ENoteType.Normal);
+        }
+    }
+
+    private void ToggleNoteType(ENoteType noteType)
+    {
+        List<Note> selectedNotes = selectionController.GetSelectedNotes();
+        bool allHaveNoteType = selectedNotes.AllMatch(it => it.Type == noteType);
+        ENoteType targetNoteType = (allHaveNoteType) ? ENoteType.Normal : noteType;
+        foreach (Note note in selectedNotes)
+        {
+            note.SetType(targetNoteType);
+        }
+
+        editorNoteDisplayer.UpdateNotesAndSentences();
     }
 
     // Implements keyboard shortcuts similar to Yass.


### PR DESCRIPTION
### What does this PR do?

- add keyboard shortcuts to make notes golden, freestyle, normal (by pressing G / F / N).
- make golden and freestyle notes visually more distinct by changing their font.

Also: refactoring of "move notes" and "extend notes" into proper song editor actions. This fixes undo/redo not working for these actions.

### More

- I already updated the documentation.
