### PR TITLE
Anst/song editor alternating sentence rectangle colors

### DIFF
--- a/UltraStar Play/Assets/Common/Util/Extensions/ImageExtensions.cs
+++ b/UltraStar Play/Assets/Common/Util/Extensions/ImageExtensions.cs
@@ -8,4 +8,28 @@ public static class ImageExtensions
         Color lastColor = image.color;
         image.color = new Color(lastColor.r, lastColor.g, lastColor.b, newAlpha);
     }
+
+    // Make the color of an image darker with a factor < 1, or brighter with a factor > 1.
+    public static void MultiplyColor(this Image image, float factor, bool includeAlpha = false)
+    {
+        Color lastColor = image.color;
+        float newR = Limit(lastColor.r * factor, 0, 1);
+        float newG = Limit(lastColor.g * factor, 0, 1);
+        float newB = Limit(lastColor.b * factor, 0, 1);
+        float newAlpha = includeAlpha ? Limit(lastColor.a * factor, 0, 1) : lastColor.a;
+        image.color = new Color(newR, newG, newB, newAlpha);
+    }
+
+    private static float Limit(float value, float min, float max)
+    {
+        if (value < min)
+        {
+            return min;
+        }
+        if (value > max)
+        {
+            return max;
+        }
+        return value;
+    }
 }

--- a/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerUiController/BeatGridDisplayer.cs
+++ b/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerUiController/BeatGridDisplayer.cs
@@ -31,6 +31,13 @@ public class BeatGridDisplayer : MonoBehaviour
 
     private void CreateLines(int StartBeat, int EndBeat)
     {
+        // This script is only for debugging
+        if (!Application.isEditor)
+        {
+            gameObject.SetActive(false);
+            return;
+        }
+
         int lengthInBeats = EndBeat - StartBeat;
 
         for (int i = 0; i <= lengthInBeats; i++)

--- a/UltraStar Play/Assets/Scenes/Sing/SingScene.unity
+++ b/UltraStar Play/Assets/Scenes/Sing/SingScene.unity
@@ -2050,11 +2050,6 @@ PrefabInstance:
       propertyPath: m_Name
       value: Lyrics
       objectReference: {fileID: 0}
-    - target: {fileID: 6263258894705517097, guid: 5ca122de3e6e3e046b5afdf99555504c,
-        type: 3}
-      propertyPath: m_Name
-      value: PositionInLyricsIndicator
-      objectReference: {fileID: 0}
     - target: {fileID: 1570843823581990794, guid: 5ca122de3e6e3e046b5afdf99555504c,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -2164,6 +2159,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_FontData.m_Alignment
       value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 6263258894705517097, guid: 5ca122de3e6e3e046b5afdf99555504c,
+        type: 3}
+      propertyPath: m_Name
+      value: PositionInLyricsIndicator
       objectReference: {fileID: 0}
     - target: {fileID: 1570843823581990805, guid: 5ca122de3e6e3e046b5afdf99555504c,
         type: 3}

--- a/UltraStar Play/Assets/Scenes/SongEditor/EditorNote/EditorNoteDisplayer.cs
+++ b/UltraStar Play/Assets/Scenes/SongEditor/EditorNote/EditorNoteDisplayer.cs
@@ -168,7 +168,6 @@ public class EditorNoteDisplayer : MonoBehaviour, INeedInjection, ISceneInjectio
             {
                 float xStartPercent = (float)noteArea.GetHorizontalPositionForBeat(sentence.MinBeat);
                 float xEndPercent = (float)noteArea.GetHorizontalPositionForBeat(sentence.ExtendedMaxBeat);
-                string label = (sentenceIndex + 1).ToString();
 
                 // Do not draw the sentence marker lines, when there are too many beats
                 if (viewportWidthInBeats < 1200)
@@ -177,7 +176,7 @@ public class EditorNoteDisplayer : MonoBehaviour, INeedInjection, ISceneInjectio
                     CreateSentenceMarkerLine(xEndPercent, Colors.black, 20);
                 }
 
-                CreateUiSentence(sentence, xStartPercent, xEndPercent, label);
+                CreateUiSentence(sentence, xStartPercent, xEndPercent, sentenceIndex);
             }
             sentenceIndex++;
         }
@@ -295,14 +294,22 @@ public class EditorNoteDisplayer : MonoBehaviour, INeedInjection, ISceneInjectio
         }
     }
 
-    private void CreateUiSentence(Sentence sentence, float xStartPercent, float xEndPercent, string label)
+    private void CreateUiSentence(Sentence sentence, float xStartPercent, float xEndPercent, int sentenceIndex)
     {
         EditorUiSentence uiSentence = Instantiate(sentenceMarkerRectanglePrefab, sentenceMarkerRectangleContainer);
 
         injector.Inject(uiSentence);
         injector.Inject(uiSentence.GetComponent<EditorSentenceContextMenuHandler>());
         uiSentence.Init(sentence);
+        string label = (sentenceIndex + 1).ToString();
         uiSentence.SetText(label);
+
+        // Make sentence rectangles alternating light/dark
+        bool isDark = (sentenceIndex % 2) == 0;
+        if (isDark)
+        {
+            uiSentence.backgroundImage.MultiplyColor(0.66f);
+        }
 
         PositionUiSentence(uiSentence.RectTransform, xStartPercent, xEndPercent);
     }

--- a/UltraStar Play/ProjectSettings/GraphicsSettings.asset
+++ b/UltraStar Play/ProjectSettings/GraphicsSettings.asset
@@ -38,6 +38,7 @@ GraphicsSettings:
   - {fileID: 16000, guid: 0000000000000000f000000000000000, type: 0}
   - {fileID: 17000, guid: 0000000000000000f000000000000000, type: 0}
   - {fileID: 16001, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 16003, guid: 0000000000000000f000000000000000, type: 0}
   m_PreloadedShaders: []
   m_SpritesDefaultMaterial: {fileID: 10754, guid: 0000000000000000f000000000000000,
     type: 0}

--- a/UltraStar Play/ProjectSettings/ProjectSettings.asset
+++ b/UltraStar Play/ProjectSettings/ProjectSettings.asset
@@ -281,7 +281,99 @@ PlayerSettings:
       m_Width: 128
       m_Height: 128
       m_Kind: 0
-  m_BuildTargetPlatformIcons: []
+  m_BuildTargetPlatformIcons:
+  - m_BuildTarget: Android
+    m_Icons:
+    - m_Textures: []
+      m_Width: 432
+      m_Height: 432
+      m_Kind: 2
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 324
+      m_Height: 324
+      m_Kind: 2
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 216
+      m_Height: 216
+      m_Kind: 2
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 162
+      m_Height: 162
+      m_Kind: 2
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 108
+      m_Height: 108
+      m_Kind: 2
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 81
+      m_Height: 81
+      m_Kind: 2
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 192
+      m_Height: 192
+      m_Kind: 0
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 144
+      m_Height: 144
+      m_Kind: 0
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 96
+      m_Height: 96
+      m_Kind: 0
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 72
+      m_Height: 72
+      m_Kind: 0
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 48
+      m_Height: 48
+      m_Kind: 0
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 36
+      m_Height: 36
+      m_Kind: 0
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 192
+      m_Height: 192
+      m_Kind: 1
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 144
+      m_Height: 144
+      m_Kind: 1
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 96
+      m_Height: 96
+      m_Kind: 1
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 72
+      m_Height: 72
+      m_Kind: 1
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 48
+      m_Height: 48
+      m_Kind: 1
+      m_SubKind: 
+    - m_Textures: []
+      m_Width: 36
+      m_Height: 36
+      m_Kind: 1
+      m_SubKind: 
   m_BuildTargetBatching: []
   m_BuildTargetGraphicsAPIs: []
   m_BuildTargetVRSettings: []


### PR DESCRIPTION
### What does this PR do?

- SongEditor: draw sentence rectangles alternatingly dark/light 
    - I had a song with overlapping sentences and this makes it easier to see sentence borders
- SingScene.BeatGridDisplayer: only display beat grid when in Unity editor
    - I once added the beat grid only for debugging. It should not go into the normal game.
- I built the project successfully for Android and started it on my phone. Thereby, the project settings were extended by Unity itself
