### PR TITLE
Anst/song editor videogap

### DIFF
--- a/UltraStar Play/Assets/Common/Model/Song/UltraStarSongFileWriter.cs
+++ b/UltraStar Play/Assets/Common/Model/Song/UltraStarSongFileWriter.cs
@@ -110,7 +110,7 @@ public static class UltraStarSongFileWriter
         AppendHeaderField(sb, "artist", songMeta.Artist);
         AppendHeaderField(sb, "mp3", songMeta.Mp3);
         AppendHeaderField(sb, "bpm", songMeta.Bpm.ToString());
-        if (songMeta.Gap > 0)
+        if (songMeta.Gap != 0)
         {
             AppendHeaderField(sb, "gap", songMeta.Gap.ToString());
         }
@@ -119,7 +119,7 @@ public static class UltraStarSongFileWriter
         AppendHeaderField(sb, "background", songMeta.Background);
 
         AppendHeaderField(sb, "video", songMeta.Video);
-        if (songMeta.VideoGap > 0)
+        if (songMeta.VideoGap != 0)
         {
             AppendHeaderField(sb, "videogap", songMeta.VideoGap.ToString());
         }
@@ -133,11 +133,11 @@ public static class UltraStarSongFileWriter
         AppendHeaderField(sb, "language", songMeta.Language);
         AppendHeaderField(sb, "edition", songMeta.Edition);
 
-        if (songMeta.Start > 0)
+        if (songMeta.Start != 0)
         {
             AppendHeaderField(sb, "start", songMeta.Start.ToString());
         }
-        if (songMeta.End > 0)
+        if (songMeta.End != 0)
         {
             AppendHeaderField(sb, "end", songMeta.End.ToString());
         }

--- a/UltraStar Play/Assets/Common/Scene/CommonSceneObjects.prefab
+++ b/UltraStar Play/Assets/Common/Scene/CommonSceneObjects.prefab
@@ -741,6 +741,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 3e93c0dde7c57c84e83e94fbbc59270d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  cursorUiTextPrefab: {fileID: 8535854030440949839, guid: 3b9040440d5af904191b4d0192896345,
+    type: 3}
   cursorTexture: {fileID: 2800000, guid: 21b89c5b005b2324d96976212a0b264d, type: 3}
   horizontalCursorTexture: {fileID: 2800000, guid: d9dca9853288ebd47a8a128193d2e8d6,
     type: 3}

--- a/UltraStar Play/Assets/Common/UI/CursorManager.cs
+++ b/UltraStar Play/Assets/Common/UI/CursorManager.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using UnityEngine;
 using UniInject;
 using UniRx;
+using UnityEngine.UI;
+using System;
 
 #pragma warning disable CS0649
 
@@ -22,6 +24,23 @@ public class CursorManager : MonoBehaviour, INeedInjection
     private static readonly Vector2 cursorTopLeftCorner = Vector2.zero;
     private static readonly Vector2 cursorCenter = new Vector2(cursorWidth / 2f, cursorWidth / 2f);
 
+    [InjectedInInspector]
+    public Text cursorUiTextPrefab;
+
+    public Text CursorUiText
+    {
+        get
+        {
+            if (cursorUiText == null)
+            {
+                Canvas canvas = CanvasUtils.FindCanvas();
+                cursorUiText = Instantiate(cursorUiTextPrefab, canvas.transform);
+            }
+            return cursorUiText;
+        }
+    }
+    private Text cursorUiText;
+
     [Inject]
     private SettingsManager settingsManager;
 
@@ -36,6 +55,11 @@ public class CursorManager : MonoBehaviour, INeedInjection
         settingsManager.Settings.GraphicSettings
             .ObserveEveryValueChanged(it => it.useImageAsCursor).Subscribe(newValue => SetDefaultCursor());
         SetDefaultCursor();
+    }
+
+    void Update()
+    {
+        UpdateCursorText();
     }
 
     public void SetDefaultCursor()
@@ -83,5 +107,29 @@ public class CursorManager : MonoBehaviour, INeedInjection
     private bool UseImageAsCursor()
     {
         return settingsManager.Settings.GraphicSettings.useImageAsCursor;
+    }
+
+    public void SetCursorText(string value, bool setVisible = true)
+    {
+        if (setVisible)
+        {
+            SetCursorTextVisible(true);
+        }
+        CursorUiText.text = value;
+    }
+
+    public void SetCursorTextVisible(bool isVisible)
+    {
+        CursorUiText.enabled = isVisible;
+    }
+
+    private void UpdateCursorText()
+    {
+        if (!CursorUiText.enabled)
+        {
+            return;
+        }
+
+        CursorUiText.GetComponent<RectTransform>().position = Input.mousePosition;
     }
 }

--- a/UltraStar Play/Assets/Common/UI/CursorUiText.prefab
+++ b/UltraStar Play/Assets/Common/UI/CursorUiText.prefab
@@ -1,0 +1,81 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1154701893727021508
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7141484449800633943}
+  - component: {fileID: 1401988019321270043}
+  - component: {fileID: 8535854030440949839}
+  m_Layer: 5
+  m_Name: CursorUiText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7141484449800633943
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1154701893727021508}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 115.4, y: -52.8835}
+  m_SizeDelta: {x: 230.8, y: 52.883}
+  m_Pivot: {x: 0.5, y: 0}
+--- !u!222 &1401988019321270043
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1154701893727021508}
+  m_CullTransparentMesh: 0
+--- !u!114 &8535854030440949839
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1154701893727021508}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 20
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 2
+    m_MaxSize: 40
+    m_Alignment: 1
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: CursorUiText

--- a/UltraStar Play/Assets/Common/UI/CursorUiText.prefab.meta
+++ b/UltraStar Play/Assets/Common/UI/CursorUiText.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3b9040440d5af904191b4d0192896345
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UltraStar Play/Assets/Common/UI/Drag.meta
+++ b/UltraStar Play/Assets/Common/UI/Drag.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 71883a261b7ff274885a7c0006759afb
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UltraStar Play/Assets/Common/UI/Drag/AbstractDragHandler.cs
+++ b/UltraStar Play/Assets/Common/UI/Drag/AbstractDragHandler.cs
@@ -1,0 +1,156 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using UnityEngine.UI;
+using UniInject;
+using UniRx;
+using UnityEngine.EventSystems;
+
+// Disable warning about fields that are never assigned, their values are injected.
+#pragma warning disable CS0649
+
+abstract public class AbstractDragHandler<EVENT> : MonoBehaviour, INeedInjection, IBeginDragHandler, IEndDragHandler, IDragHandler
+{
+    private readonly List<IDragListener<EVENT>> dragListeners = new List<IDragListener<EVENT>>();
+
+    [Inject]
+    public GraphicRaycaster graphicRaycaster;
+
+    private bool isDragging;
+    private bool ignoreDrag;
+
+    private EVENT dragStartEvent;
+
+    public RectTransform targetRectTransform;
+
+    void Update()
+    {
+        // Cancel drag via Escape key
+        if (isDragging && Input.GetKeyUp(KeyCode.Escape))
+        {
+            CancelDrag();
+        }
+    }
+
+    public void AddListener(IDragListener<EVENT> listener)
+    {
+        dragListeners.Add(listener);
+    }
+
+    public void RemoveListener(IDragListener<EVENT> listener)
+    {
+        dragListeners.Remove(listener);
+    }
+
+    public void OnBeginDrag(PointerEventData eventData)
+    {
+        ignoreDrag = false;
+        isDragging = true;
+        dragStartEvent = CreateDragEventStart(eventData);
+        NotifyListeners(listener => listener.OnBeginDrag(dragStartEvent), true);
+    }
+
+    public void OnDrag(PointerEventData eventData)
+    {
+        if (ignoreDrag)
+        {
+            return;
+        }
+
+        EVENT dragEvent = CreateDragEvent(eventData, dragStartEvent);
+        NotifyListeners(listener => listener.OnDrag(dragEvent), false);
+    }
+
+    public void OnEndDrag(PointerEventData eventData)
+    {
+        if (ignoreDrag)
+        {
+            return;
+        }
+
+        EVENT dragEvent = CreateDragEvent(eventData, dragStartEvent);
+        NotifyListeners(listener => listener.OnEndDrag(dragEvent), false);
+        isDragging = false;
+    }
+
+    private void CancelDrag()
+    {
+        if (ignoreDrag)
+        {
+            return;
+        }
+
+        isDragging = false;
+        ignoreDrag = true;
+        NotifyListeners(listener => listener.CancelDrag(), false);
+    }
+
+    private void NotifyListeners(Action<IDragListener<EVENT>> action, bool includeCanceledListeners)
+    {
+        foreach (IDragListener<EVENT> listener in dragListeners)
+        {
+            if (includeCanceledListeners || !listener.IsCanceled())
+            {
+                action(listener);
+            }
+        }
+    }
+
+    abstract protected EVENT CreateDragEventStart(PointerEventData eventData);
+    abstract protected EVENT CreateDragEvent(PointerEventData eventData, EVENT dragStartEvent);
+
+    protected GeneralDragEvent CreateGeneralDragEvent(PointerEventData eventData, GeneralDragEvent dragStartEvent)
+    {
+        float xDistanceInPixels = eventData.position.x - dragStartEvent.StartPositionInPixels.x;
+        float yDistanceInPixels = eventData.position.y - dragStartEvent.StartPositionInPixels.y;
+
+        float widthInPixels = targetRectTransform.rect.width;
+        float heightInPixels = targetRectTransform.rect.height;
+        float xDistanceInPercent = xDistanceInPixels / widthInPixels;
+        float yDistanceInPercent = yDistanceInPixels / heightInPixels;
+
+        GeneralDragEvent result = new GeneralDragEvent(dragStartEvent.StartPositionInPixels,
+            dragStartEvent.StartPositionInPercent,
+            new Vector2(xDistanceInPixels, yDistanceInPixels),
+            new Vector2(xDistanceInPercent, yDistanceInPercent),
+            dragStartEvent.RaycastResultsDragStart,
+            dragStartEvent.InputButton);
+        return result;
+    }
+
+    protected GeneralDragEvent CreateGeneralDragEventStart(PointerEventData eventData)
+    {
+        float xDragStartInPixels = eventData.pressPosition.x;
+        float yDragStartInPixels = eventData.pressPosition.y;
+        float xDistanceInPixels = 0;
+        float yDistanceInPixels = 0;
+
+        List<RaycastResult> raycastResults = new List<RaycastResult>();
+        PointerEventData eventDataForRaycast = new PointerEventData(EventSystem.current);
+        eventDataForRaycast.position = eventData.pressPosition;
+        graphicRaycaster.Raycast(eventDataForRaycast, raycastResults);
+
+        RectTransformUtility.ScreenPointToLocalPointInRectangle(targetRectTransform,
+                                                                eventData.pressPosition,
+                                                                eventData.pressEventCamera,
+                                                                out Vector2 localPoint);
+
+        float widthInPixels = targetRectTransform.rect.width;
+        float heightInPixels = targetRectTransform.rect.height;
+        float xDragStartInPercent = (localPoint.x + (widthInPixels / 2)) / widthInPixels;
+        float yDragStartInPercent = (localPoint.y + (heightInPixels / 2)) / heightInPixels;
+
+        float xDistanceInPercent = 0;
+        float yDistanceInPercent = 0;
+
+        GeneralDragEvent result = new GeneralDragEvent(new Vector2(xDragStartInPixels, yDragStartInPixels),
+            new Vector2(xDragStartInPercent, yDragStartInPercent),
+            new Vector2(xDistanceInPixels, yDistanceInPixels),
+            new Vector2(xDistanceInPercent, yDistanceInPercent),
+            raycastResults,
+            eventData.button);
+        return result;
+    }
+}

--- a/UltraStar Play/Assets/Common/UI/Drag/AbstractDragHandler.cs.meta
+++ b/UltraStar Play/Assets/Common/UI/Drag/AbstractDragHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 28e66bcfb64375949917a8bc6eb71d33
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UltraStar Play/Assets/Common/UI/Drag/GeneralDragEvent.cs
+++ b/UltraStar Play/Assets/Common/UI/Drag/GeneralDragEvent.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.EventSystems;
+
+public class GeneralDragEvent
+{
+    public PointerEventData.InputButton InputButton { get; private set; }
+
+    public List<RaycastResult> RaycastResultsDragStart { get; private set; }
+
+    public Vector2 StartPositionInPixels { get; private set; }
+    public Vector2 StartPositionInPercent { get; private set; }
+
+    public Vector2 DistanceInPixels { get; private set; }
+    public Vector2 DistanceInPercent { get; private set; }
+
+    public GeneralDragEvent(Vector2 dragStartInPixels,
+        Vector2 dragStartInPercent,
+        Vector2 distanceInPixels,
+        Vector2 distanceInPercent,
+        List<RaycastResult> raycastResultsDragStart,
+        PointerEventData.InputButton inputButton)
+    {
+        StartPositionInPixels = dragStartInPixels;
+        StartPositionInPercent = dragStartInPercent;
+
+        DistanceInPixels = distanceInPixels;
+        DistanceInPercent = distanceInPercent;
+
+        RaycastResultsDragStart = raycastResultsDragStart;
+
+        InputButton = inputButton;
+    }
+
+}

--- a/UltraStar Play/Assets/Common/UI/Drag/GeneralDragEvent.cs.meta
+++ b/UltraStar Play/Assets/Common/UI/Drag/GeneralDragEvent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d365350bb53bc4f4bb17aca5af1a5436
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UltraStar Play/Assets/Common/UI/Drag/GeneralDragHandler.cs
+++ b/UltraStar Play/Assets/Common/UI/Drag/GeneralDragHandler.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using UnityEngine.UI;
+using UniInject;
+using UniRx;
+using UnityEngine.EventSystems;
+
+// Disable warning about fields that are never assigned, their values are injected.
+#pragma warning disable CS0649
+
+public class GeneralDragHandler : AbstractDragHandler<GeneralDragEvent>
+{
+    protected override GeneralDragEvent CreateDragEventStart(PointerEventData eventData)
+    {
+        return CreateGeneralDragEventStart(eventData);
+    }
+
+    protected override GeneralDragEvent CreateDragEvent(PointerEventData eventData, GeneralDragEvent dragStartEvent)
+    {
+        return CreateGeneralDragEvent(eventData, dragStartEvent);
+    }
+}

--- a/UltraStar Play/Assets/Common/UI/Drag/GeneralDragHandler.cs.meta
+++ b/UltraStar Play/Assets/Common/UI/Drag/GeneralDragHandler.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: e7b18c7a3396c7c47b94bcd1a025bf52
+guid: 39cfa29b34b249142b8bd9eb5b1824a7
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/UltraStar Play/Assets/Common/UI/Drag/IDragListener.cs
+++ b/UltraStar Play/Assets/Common/UI/Drag/IDragListener.cs
@@ -1,0 +1,9 @@
+public interface IDragListener<EVENT>
+{
+    void OnBeginDrag(EVENT dragEvent);
+    void OnDrag(EVENT dragEvent);
+    void OnEndDrag(EVENT dragEvent);
+
+    void CancelDrag();
+    bool IsCanceled();
+}

--- a/UltraStar Play/Assets/Common/UI/Drag/IDragListener.cs.meta
+++ b/UltraStar Play/Assets/Common/UI/Drag/IDragListener.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 285fab686a45281468eb5434bbb0c578
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UltraStar Play/Assets/Scenes/Sing/SongVideoPlayer.cs
+++ b/UltraStar Play/Assets/Scenes/Sing/SongVideoPlayer.cs
@@ -115,7 +115,7 @@ public class SongVideoPlayer : MonoBehaviour
         }
     }
 
-    private void SyncVideoWithMusic(double positionInSongInMillis)
+    public void SyncVideoWithMusic(double positionInSongInMillis, bool forceImmediateSync = false)
     {
         if (!hasLoadedVideo || IsWaitingForVideoGap(positionInSongInMillis) || nextSyncTimeInSeconds > Time.time)
         {
@@ -130,7 +130,7 @@ public class SongVideoPlayer : MonoBehaviour
 
         // A short mismatch in video and song position is smoothed out by adjusting the playback speed of the video.
         // A big mismatch is corrected immediately.
-        if (Math.Abs(timeDifferenceInSeconds) > 2)
+        if (forceImmediateSync || Math.Abs(timeDifferenceInSeconds) > 2)
         {
             // Correct the mismatch immediately.
             videoPlayer.time = targetPositionInVideoInSeconds;

--- a/UltraStar Play/Assets/Scenes/SongEditor/Actions/SetVideoGapAction.cs
+++ b/UltraStar Play/Assets/Scenes/SongEditor/Actions/SetVideoGapAction.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using UnityEngine.UI;
+using UniInject;
+using UniRx;
+
+// Disable warning about fields that are never assigned, their values are injected.
+#pragma warning disable CS0649
+
+public class SetVideoGapAction : INeedInjection
+{
+
+    [Inject]
+    private SongMeta songMeta;
+
+    [Inject]
+    private SongAudioPlayer songAudioPlayer;
+
+    [Inject]
+    private SongVideoPlayer songVideoPlayer;
+
+    [Inject]
+    private SongMetaChangeEventStream songMetaChangeEventStream;
+
+    public void Execute(float newVideoGap)
+    {
+        songMeta.VideoGap = newVideoGap;
+        songVideoPlayer.SyncVideoWithMusic(songAudioPlayer.PositionInSongInMillis, true);
+    }
+
+    public void ExecuteAndNotify(float newVideoGap)
+    {
+        Execute(newVideoGap);
+        songMetaChangeEventStream.OnNext(new VideoGapChangedEvent());
+    }
+}

--- a/UltraStar Play/Assets/Scenes/SongEditor/Actions/SetVideoGapAction.cs.meta
+++ b/UltraStar Play/Assets/Scenes/SongEditor/Actions/SetVideoGapAction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f1e530d90f95d4a43ac6f404f22d2e93
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UltraStar Play/Assets/Scenes/SongEditor/Actions/SongEditorActionBinder.cs
+++ b/UltraStar Play/Assets/Scenes/SongEditor/Actions/SongEditorActionBinder.cs
@@ -27,6 +27,7 @@ public class SongEditorActionBinder : MonoBehaviour, IBinder
         bb.BindTypeToNewInstances(typeof(SentenceFitToNoteAction));
 
         bb.BindTypeToNewInstances(typeof(SetMusicGapAction));
+        bb.BindTypeToNewInstances(typeof(SetVideoGapAction));
         bb.BindTypeToNewInstances(typeof(ChangeBpmAction));
         return bb.GetBindings();
     }

--- a/UltraStar Play/Assets/Scenes/SongEditor/NoteArea/Drag/INoteAreaDragListener.cs
+++ b/UltraStar Play/Assets/Scenes/SongEditor/NoteArea/Drag/INoteAreaDragListener.cs
@@ -1,9 +1,0 @@
-public interface INoteAreaDragListener
-{
-    void OnBeginDrag(NoteAreaDragEvent dragEvent);
-    void OnDrag(NoteAreaDragEvent dragEvent);
-    void OnEndDrag(NoteAreaDragEvent dragEvent);
-
-    void CancelDrag();
-    bool IsCanceled();
-}

--- a/UltraStar Play/Assets/Scenes/SongEditor/NoteArea/Drag/ManipulateNotesDragListener.cs
+++ b/UltraStar Play/Assets/Scenes/SongEditor/NoteArea/Drag/ManipulateNotesDragListener.cs
@@ -11,7 +11,7 @@ using UnityEngine.EventSystems;
 // Disable warning about fields that are never assigned, their values are injected.
 #pragma warning disable CS0649
 
-public class ManipulateNotesDragListener : MonoBehaviour, INeedInjection, INoteAreaDragListener
+public class ManipulateNotesDragListener : MonoBehaviour, INeedInjection, IDragListener<NoteAreaDragEvent>
 {
     [Inject]
     private SongEditorSelectionController selectionController;
@@ -58,14 +58,14 @@ public class ManipulateNotesDragListener : MonoBehaviour, INeedInjection, INoteA
 
     public void OnBeginDrag(NoteAreaDragEvent dragEvent)
     {
-        if (dragEvent.InputButton != PointerEventData.InputButton.Left)
+        if (dragEvent.GeneralDragEvent.InputButton != PointerEventData.InputButton.Left)
         {
             CancelDrag();
             return;
         }
 
         isCanceled = false;
-        GameObject raycastTarget = dragEvent.RaycastResultsDragStart.Select(it => it.gameObject).FirstOrDefault();
+        GameObject raycastTarget = dragEvent.GeneralDragEvent.RaycastResultsDragStart.Select(it => it.gameObject).FirstOrDefault();
         EditorUiNote dragStartUiNote = raycastTarget.GetComponent<EditorUiNote>();
         if (dragStartUiNote == null)
         {
@@ -164,11 +164,11 @@ public class ManipulateNotesDragListener : MonoBehaviour, INeedInjection, INoteA
 
     private DragAction GetDragAction(EditorUiNote dragStartUiNote, NoteAreaDragEvent dragEvent)
     {
-        if (dragStartUiNote.IsPositionOverLeftHandle(dragEvent.DragStartPositionInPixels))
+        if (dragStartUiNote.IsPositionOverLeftHandle(dragEvent.GeneralDragEvent.StartPositionInPixels))
         {
             return DragAction.StretchLeft;
         }
-        else if (dragStartUiNote.IsPositionOverRightHandle(dragEvent.DragStartPositionInPixels))
+        else if (dragStartUiNote.IsPositionOverRightHandle(dragEvent.GeneralDragEvent.StartPositionInPixels))
         {
             return DragAction.StretchRight;
         }
@@ -177,7 +177,7 @@ public class ManipulateNotesDragListener : MonoBehaviour, INeedInjection, INoteA
 
     private DragDirection GetDragDirection(NoteAreaDragEvent dragEvent)
     {
-        if (Math.Abs(dragEvent.YDistanceInPixels) > Math.Abs(dragEvent.XDistanceInPixels))
+        if (Math.Abs(dragEvent.GeneralDragEvent.DistanceInPixels.y) > Math.Abs(dragEvent.GeneralDragEvent.DistanceInPixels.x))
         {
             return DragDirection.Vertical;
         }

--- a/UltraStar Play/Assets/Scenes/SongEditor/NoteArea/Drag/NoteAreaDragEvent.cs
+++ b/UltraStar Play/Assets/Scenes/SongEditor/NoteArea/Drag/NoteAreaDragEvent.cs
@@ -4,15 +4,7 @@ using UnityEngine.EventSystems;
 
 public class NoteAreaDragEvent
 {
-    public PointerEventData.InputButton InputButton { get; private set; }
-
-    public float XDragStartInPixels { get; private set; }
-    public float YDragStartInPixels { get; private set; }
-
-    public float YDistanceInPixels { get; private set; }
-    public float XDistanceInPixels { get; private set; }
-
-    public Vector2 DragStartPositionInPixels { get; private set; }
+    public GeneralDragEvent GeneralDragEvent { get; private set; }
 
     public int MidiNoteDragStart { get; private set; }
     public int MidiNoteDistance { get; private set; }
@@ -23,30 +15,20 @@ public class NoteAreaDragEvent
     public int PositionInSongInBeatsDragStart { get; private set; }
     public int BeatDistance { get; private set; }
 
-    public List<RaycastResult> RaycastResultsDragStart { get; private set; }
-
-    public NoteAreaDragEvent(float xDragStartInPixels, float yDragStartInPixels,
-        float xDistanceInPixels, float yDistanceInPixels,
+    public NoteAreaDragEvent(GeneralDragEvent generalDragEvent,
         int midiNoteDragStart, int midiNoteDistance,
         int positionInSongInMillisDragStart, int millisDistance,
-        int positionInSongInBeatsDragStart, int beatDistance,
-        List<RaycastResult> raycastResultsDragStart,
-        PointerEventData.InputButton inputButton)
+        int positionInSongInBeatsDragStart, int beatDistance)
     {
-        XDragStartInPixels = xDragStartInPixels;
-        YDragStartInPixels = yDragStartInPixels;
-        XDistanceInPixels = xDistanceInPixels;
-        YDistanceInPixels = yDistanceInPixels;
+        GeneralDragEvent = generalDragEvent;
+
         MidiNoteDragStart = midiNoteDragStart;
         MidiNoteDistance = midiNoteDistance;
+
         PositionInSongInMillisDragStart = positionInSongInMillisDragStart;
         MillisDistance = millisDistance;
+
         PositionInSongInBeatsDragStart = positionInSongInBeatsDragStart;
         BeatDistance = beatDistance;
-        RaycastResultsDragStart = raycastResultsDragStart;
-
-        DragStartPositionInPixels = new Vector2(xDragStartInPixels, yDragStartInPixels);
-
-        InputButton = inputButton;
     }
 }

--- a/UltraStar Play/Assets/Scenes/SongEditor/NoteArea/Drag/NoteAreaDragHandler.cs
+++ b/UltraStar Play/Assets/Scenes/SongEditor/NoteArea/Drag/NoteAreaDragHandler.cs
@@ -11,175 +11,55 @@ using UnityEngine.EventSystems;
 // Disable warning about fields that are never assigned, their values are injected.
 #pragma warning disable CS0649
 
-public class NoteAreaDragHandler : MonoBehaviour, INeedInjection, IBeginDragHandler, IEndDragHandler, IDragHandler
+public class NoteAreaDragHandler : AbstractDragHandler<NoteAreaDragEvent>
 {
-    private readonly List<INoteAreaDragListener> dragListeners = new List<INoteAreaDragListener>();
-
     [Inject]
     private NoteArea noteArea;
 
-    [Inject]
-    private Canvas canvas;
-
-    [Inject]
-    private GraphicRaycaster graphicRaycaster;
-
-    private bool isDragging;
-    private bool ignoreDrag;
-
-    private NoteAreaDragEvent dragStartEvent;
-
-    private RectTransform noteAreaRectTransform;
-
     void Start()
     {
-        noteAreaRectTransform = noteArea.GetComponent<RectTransform>();
+        targetRectTransform = noteArea.GetComponent<RectTransform>();
     }
 
-    void Update()
+    protected override NoteAreaDragEvent CreateDragEventStart(PointerEventData eventData)
     {
-        // Cancel drag via Escape key
-        if (isDragging && Input.GetKeyUp(KeyCode.Escape))
-        {
-            CancelDrag();
-        }
-    }
+        GeneralDragEvent generalDragEvent = CreateGeneralDragEventStart(eventData);
 
-    public void AddListener(INoteAreaDragListener listener)
-    {
-        dragListeners.Add(listener);
-    }
+        int midiNoteDragStart = (int)(noteArea.ViewportY + generalDragEvent.StartPositionInPercent.y * noteArea.ViewportHeight);
+        int midiNoteDistance = 0;
 
-    public void RemoveListener(INoteAreaDragListener listener)
-    {
-        dragListeners.Remove(listener);
-    }
+        int positionInSongInMillisDragStart = (int)(noteArea.ViewportX + generalDragEvent.StartPositionInPercent.x * noteArea.ViewportWidth);
+        int millisDistance = 0;
 
-    public void OnBeginDrag(PointerEventData eventData)
-    {
-        ignoreDrag = false;
-        isDragging = true;
-        dragStartEvent = CreateNoteAreaBeginDragEvent(eventData);
-        NotifyListeners(listener => listener.OnBeginDrag(dragStartEvent), true);
-    }
+        int positionInSongInBeatsDragStart = (int)(noteArea.MinBeatInViewport + generalDragEvent.StartPositionInPercent.x * noteArea.ViewportWidthInBeats);
+        int beatDistance = 0;
 
-    public void OnDrag(PointerEventData eventData)
-    {
-        if (ignoreDrag)
-        {
-            return;
-        }
-
-        NoteAreaDragEvent dragEvent = CreateNoteAreaDragEvent(eventData, dragStartEvent);
-        NotifyListeners(listener => listener.OnDrag(dragEvent), false);
-    }
-
-    public void OnEndDrag(PointerEventData eventData)
-    {
-        if (ignoreDrag)
-        {
-            return;
-        }
-
-        NoteAreaDragEvent dragEvent = CreateNoteAreaDragEvent(eventData, dragStartEvent);
-        NotifyListeners(listener => listener.OnEndDrag(dragEvent), false);
-        isDragging = false;
-    }
-
-    private void CancelDrag()
-    {
-        if (ignoreDrag)
-        {
-            return;
-        }
-
-        isDragging = false;
-        ignoreDrag = true;
-        NotifyListeners(listener => listener.CancelDrag(), false);
-    }
-
-    private void NotifyListeners(Action<INoteAreaDragListener> action, bool includeCanceledListeners)
-    {
-        foreach (INoteAreaDragListener listener in dragListeners)
-        {
-            if (includeCanceledListeners || !listener.IsCanceled())
-            {
-                action(listener);
-            }
-        }
-    }
-
-    private NoteAreaDragEvent CreateNoteAreaDragEvent(PointerEventData eventData, NoteAreaDragEvent dragStartEvent)
-    {
-        float xDragStartInPixels = dragStartEvent.XDragStartInPixels;
-        float yDragStartInPixels = dragStartEvent.YDragStartInPixels;
-        float xDistanceInPixels = eventData.position.x - xDragStartInPixels;
-        float yDistanceInPixels = eventData.position.y - yDragStartInPixels;
-
-        List<RaycastResult> raycastResults = dragStartEvent.RaycastResultsDragStart;
-
-        float noteAreaWidthInPixels = noteAreaRectTransform.rect.width;
-        float noteAreaHeightInPixels = noteAreaRectTransform.rect.height;
-        double xDistancePercent = xDistanceInPixels / noteAreaWidthInPixels;
-        double yDistancePercent = yDistanceInPixels / noteAreaHeightInPixels;
-
-        int midiNoteDragStart = dragStartEvent.MidiNoteDragStart;
-        int midiNoteDistance = (int)(yDistancePercent * noteArea.ViewportHeight);
-
-        int positionInSongInMillisDragStart = dragStartEvent.PositionInSongInMillisDragStart;
-        int millisDistance = (int)(xDistancePercent * noteArea.ViewportWidth);
-
-        int positionInSongInBeatsDragStart = dragStartEvent.PositionInSongInBeatsDragStart;
-        int beatDistance = (int)(xDistancePercent * noteArea.ViewportWidthInBeats);
-
-        NoteAreaDragEvent result = new NoteAreaDragEvent(xDragStartInPixels, yDragStartInPixels,
-            xDistanceInPixels, yDistanceInPixels,
+        NoteAreaDragEvent result = new NoteAreaDragEvent(generalDragEvent,
             midiNoteDragStart, midiNoteDistance,
             positionInSongInMillisDragStart, millisDistance,
-            positionInSongInBeatsDragStart, beatDistance,
-            raycastResults,
-            eventData.button);
+            positionInSongInBeatsDragStart, beatDistance);
+
         return result;
     }
 
-    private NoteAreaDragEvent CreateNoteAreaBeginDragEvent(PointerEventData eventData)
+    protected override NoteAreaDragEvent CreateDragEvent(PointerEventData eventData, NoteAreaDragEvent dragStartEvent)
     {
-        float xDragStartInPixels = eventData.pressPosition.x;
-        float yDragStartInPixels = eventData.pressPosition.y;
-        float xDistanceInPixels = 0;
-        float yDistanceInPixels = 0;
+        GeneralDragEvent generalDragEvent = CreateGeneralDragEvent(eventData, dragStartEvent.GeneralDragEvent);
 
-        List<RaycastResult> raycastResults = new List<RaycastResult>();
-        PointerEventData eventDataForRaycast = new PointerEventData(EventSystem.current);
-        eventDataForRaycast.position = eventData.pressPosition;
-        graphicRaycaster.Raycast(eventDataForRaycast, raycastResults);
+        int midiNoteDragStart = dragStartEvent.MidiNoteDragStart;
+        int midiNoteDistance = (int)(generalDragEvent.DistanceInPercent.y * noteArea.ViewportHeight);
 
-        RectTransformUtility.ScreenPointToLocalPointInRectangle(noteAreaRectTransform,
-                                                                eventData.pressPosition,
-                                                                eventData.pressEventCamera,
-                                                                out Vector2 localPoint);
+        int positionInSongInMillisDragStart = dragStartEvent.PositionInSongInMillisDragStart;
+        int millisDistance = (int)(generalDragEvent.DistanceInPercent.x * noteArea.ViewportWidth);
 
-        float noteAreaWidthInPixels = noteAreaRectTransform.rect.width;
-        float noteAreaHeightInPixels = noteAreaRectTransform.rect.height;
-        double xPercent = (localPoint.x + (noteAreaWidthInPixels / 2)) / noteAreaWidthInPixels;
-        double yPercent = (localPoint.y + (noteAreaHeightInPixels / 2)) / noteAreaHeightInPixels;
+        int positionInSongInBeatsDragStart = dragStartEvent.PositionInSongInBeatsDragStart;
+        int beatDistance = (int)(generalDragEvent.DistanceInPercent.x * noteArea.ViewportWidthInBeats);
 
-        int midiNoteDragStart = (int)(noteArea.ViewportY + yPercent * noteArea.ViewportHeight);
-        int midiNoteDistance = 0;
-
-        int positionInSongInMillisDragStart = (int)(noteArea.ViewportX + xPercent * noteArea.ViewportWidth);
-        int millisDistance = 0;
-
-        int positionInSongInBeatsDragStart = (int)(noteArea.MinBeatInViewport + xPercent * noteArea.ViewportWidthInBeats);
-        int beatDistance = 0;
-
-        NoteAreaDragEvent result = new NoteAreaDragEvent(xDragStartInPixels, yDragStartInPixels,
-            xDistanceInPixels, yDistanceInPixels,
+        NoteAreaDragEvent result = new NoteAreaDragEvent(generalDragEvent,
             midiNoteDragStart, midiNoteDistance,
             positionInSongInMillisDragStart, millisDistance,
-            positionInSongInBeatsDragStart, beatDistance,
-            raycastResults,
-            eventData.button);
+            positionInSongInBeatsDragStart, beatDistance);
+
         return result;
     }
 }

--- a/UltraStar Play/Assets/Scenes/SongEditor/NoteArea/Drag/NoteAreaSelectionDragListener.cs
+++ b/UltraStar Play/Assets/Scenes/SongEditor/NoteArea/Drag/NoteAreaSelectionDragListener.cs
@@ -11,7 +11,7 @@ using UnityEngine.EventSystems;
 // Disable warning about fields that are never assigned, their values are injected.
 #pragma warning disable CS0649
 
-public class NoteAreaSelectionDragListener : MonoBehaviour, INeedInjection, INoteAreaDragListener
+public class NoteAreaSelectionDragListener : MonoBehaviour, INeedInjection, IDragListener<NoteAreaDragEvent>
 {
     [InjectedInInspector]
     public RectTransform selectionFrame;
@@ -38,13 +38,13 @@ public class NoteAreaSelectionDragListener : MonoBehaviour, INeedInjection, INot
     public void OnBeginDrag(NoteAreaDragEvent dragEvent)
     {
         isCanceled = false;
-        if (dragEvent.InputButton != PointerEventData.InputButton.Left)
+        if (dragEvent.GeneralDragEvent.InputButton != PointerEventData.InputButton.Left)
         {
             CancelDrag();
             return;
         }
 
-        GameObject raycastTarget = dragEvent.RaycastResultsDragStart.Select(it => it.gameObject).FirstOrDefault();
+        GameObject raycastTarget = dragEvent.GeneralDragEvent.RaycastResultsDragStart.Select(it => it.gameObject).FirstOrDefault();
         if (raycastTarget != noteArea.gameObject)
         {
             CancelDrag();
@@ -134,10 +134,10 @@ public class NoteAreaSelectionDragListener : MonoBehaviour, INeedInjection, INot
 
     private void UpdateSelectionFrame(NoteAreaDragEvent dragEvent)
     {
-        float x = dragEvent.XDragStartInPixels;
-        float y = dragEvent.YDragStartInPixels;
-        float width = dragEvent.XDistanceInPixels;
-        float height = -dragEvent.YDistanceInPixels;
+        float x = dragEvent.GeneralDragEvent.StartPositionInPixels.x;
+        float y = dragEvent.GeneralDragEvent.StartPositionInPixels.y;
+        float width = dragEvent.GeneralDragEvent.DistanceInPixels.x;
+        float height = -dragEvent.GeneralDragEvent.DistanceInPixels.y;
 
         if (width < 0)
         {

--- a/UltraStar Play/Assets/Scenes/SongEditor/NoteArea/NoteAreaScrollingDragListener.cs
+++ b/UltraStar Play/Assets/Scenes/SongEditor/NoteArea/NoteAreaScrollingDragListener.cs
@@ -11,7 +11,7 @@ using UnityEngine.EventSystems;
 // Disable warning about fields that are never assigned, their values are injected.
 #pragma warning disable CS0649
 
-public class NoteAreaScrollingDragListener : MonoBehaviour, INeedInjection, INoteAreaDragListener
+public class NoteAreaScrollingDragListener : MonoBehaviour, INeedInjection, IDragListener<NoteAreaDragEvent>
 {
     [Inject]
     private NoteArea noteArea;
@@ -31,7 +31,7 @@ public class NoteAreaScrollingDragListener : MonoBehaviour, INeedInjection, INot
     public void OnBeginDrag(NoteAreaDragEvent dragEvent)
     {
         isCanceled = false;
-        if (dragEvent.InputButton != PointerEventData.InputButton.Middle)
+        if (dragEvent.GeneralDragEvent.InputButton != PointerEventData.InputButton.Middle)
         {
             CancelDrag();
             return;

--- a/UltraStar Play/Assets/Scenes/SongEditor/SongEditorScene.unity
+++ b/UltraStar Play/Assets/Scenes/SongEditor/SongEditorScene.unity
@@ -256,7 +256,12 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 8406948}
+  - component: {fileID: 8406951}
+  - component: {fileID: 8406954}
   - component: {fileID: 8406949}
+  - component: {fileID: 8406953}
+  - component: {fileID: 8406952}
+  - component: {fileID: 8406950}
   m_Layer: 5
   m_Name: VideoArea
   m_TagString: Untagged
@@ -301,6 +306,83 @@ MonoBehaviour:
   videoPlayer: {fileID: 201322046}
   videoImageAndPlayerContainer: {fileID: 8406947}
   backgroundImage: {fileID: 1140148223}
+--- !u!114 &8406950
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8406947}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 39cfa29b34b249142b8bd9eb5b1824a7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  graphicRaycaster: {fileID: 0}
+  targetRectTransform: {fileID: 8406948}
+--- !u!222 &8406951
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8406947}
+  m_CullTransparentMesh: 0
+--- !u!114 &8406952
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8406947}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 924b795a7d5f335468e9626fea51a04c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &8406953
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8406947}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: adc36b4ecac544041a853a1db763573e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  videoAreaDragHandler: {fileID: 8406950}
+--- !u!114 &8406954
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8406947}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &14071346
 GameObject:
   m_ObjectHideFlags: 0
@@ -10332,6 +10414,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7848e10bfe155c74da6c0329e3209221, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  graphicRaycaster: {fileID: 0}
+  targetRectTransform: {fileID: 0}
 --- !u!1 &1604233037
 GameObject:
   m_ObjectHideFlags: 0
@@ -11067,8 +11151,8 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 71010841}
   m_HandleRect: {fileID: 71010840}
   m_Direction: 2
-  m_Value: -0.00001056725
-  m_Size: 0.980211
+  m_Value: 1
+  m_Size: 0.98186994
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -13820,7 +13904,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 5.7759466}
+  m_AnchoredPosition: {x: 0, y: 0.00003599003}
   m_SizeDelta: {x: 0, y: 318.58}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &2142613635

--- a/UltraStar Play/Assets/Scenes/SongEditor/SongMetaChangeEvent/VideoGapChangedEvent.cs
+++ b/UltraStar Play/Assets/Scenes/SongEditor/SongMetaChangeEvent/VideoGapChangedEvent.cs
@@ -1,0 +1,3 @@
+public class VideoGapChangedEvent : ISongMetaChangeEvent
+{
+}

--- a/UltraStar Play/Assets/Scenes/SongEditor/SongMetaChangeEvent/VideoGapChangedEvent.cs.meta
+++ b/UltraStar Play/Assets/Scenes/SongEditor/SongMetaChangeEvent/VideoGapChangedEvent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a0ddb634fd3a027409e052e8d6a88323
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UltraStar Play/Assets/Scenes/SongEditor/VideoArea.meta
+++ b/UltraStar Play/Assets/Scenes/SongEditor/VideoArea.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c2ed5a42c2c51b64883c8805de5353ef
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UltraStar Play/Assets/Scenes/SongEditor/VideoArea/VideoArea.cs
+++ b/UltraStar Play/Assets/Scenes/SongEditor/VideoArea/VideoArea.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using UnityEngine.UI;
+using UniInject;
+using UniRx;
+using UnityEngine.EventSystems;
+using System.Globalization;
+
+// Disable warning about fields that are never assigned, their values are injected.
+#pragma warning disable CS0649
+
+public class VideoArea : MonoBehaviour, INeedInjection, IDragListener<GeneralDragEvent>, IPointerEnterHandler, IPointerExitHandler
+{
+    [InjectedInInspector]
+    public GeneralDragHandler videoAreaDragHandler;
+
+    [Inject]
+    private CursorManager cursorManager;
+
+    [Inject]
+    private SongMeta songMeta;
+
+    [Inject]
+    private SetVideoGapAction setVideoGapAction;
+
+    private bool isCanceled;
+
+    private float videoGapAtDragStart;
+
+    public void Start()
+    {
+        videoAreaDragHandler.AddListener(this);
+    }
+
+    public void CancelDrag()
+    {
+        isCanceled = true;
+    }
+
+    public bool IsCanceled()
+    {
+        return isCanceled;
+    }
+
+    public void OnBeginDrag(GeneralDragEvent dragEvent)
+    {
+        isCanceled = false;
+        if (dragEvent.InputButton != PointerEventData.InputButton.Left)
+        {
+            CancelDrag();
+            return;
+        }
+
+        videoGapAtDragStart = songMeta.VideoGap;
+    }
+
+    public void OnDrag(GeneralDragEvent dragEvent)
+    {
+        setVideoGapAction.Execute(GetNewVideoGap(dragEvent));
+        cursorManager.SetCursorText("VideoGap: " + songMeta.VideoGap);
+    }
+
+    public void OnEndDrag(GeneralDragEvent dragEvent)
+    {
+        setVideoGapAction.ExecuteAndNotify(GetNewVideoGap(dragEvent));
+        cursorManager.SetCursorTextVisible(false);
+    }
+
+    public void OnPointerEnter(PointerEventData eventData)
+    {
+        cursorManager.SetCursorHorizontal();
+    }
+
+    public void OnPointerExit(PointerEventData eventData)
+    {
+        cursorManager.SetDefaultCursor();
+        cursorManager.SetCursorTextVisible(false);
+    }
+
+    private float GetNewVideoGap(GeneralDragEvent dragEvent)
+    {
+        float videoGapDistance = dragEvent.DistanceInPercent.x * 0.5f;
+
+        // Round to 2 decimal places
+        float newVideoGap = (float)Math.Round(videoGapAtDragStart + videoGapDistance, 2);
+        return newVideoGap;
+    }
+}

--- a/UltraStar Play/Assets/Scenes/SongEditor/VideoArea/VideoArea.cs.meta
+++ b/UltraStar Play/Assets/Scenes/SongEditor/VideoArea/VideoArea.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: adc36b4ecac544041a853a1db763573e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UltraStar Play/Assets/Scenes/SongEditor/VideoArea/VideoAreaContextMenuHandler.cs
+++ b/UltraStar Play/Assets/Scenes/SongEditor/VideoArea/VideoAreaContextMenuHandler.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using UnityEngine.UI;
+using UniInject;
+using UniRx;
+
+// Disable warning about fields that are never assigned, their values are injected.
+#pragma warning disable CS0649
+
+public class VideoAreaContextMenuHandler : AbstractContextMenuHandler, INeedInjection
+{
+    [Inject]
+    private SongMeta songMeta;
+
+    [Inject]
+    private SetVideoGapAction setVideoGapAction;
+
+    [Inject]
+    private UiManager uiManager;
+
+    protected override void FillContextMenu(ContextMenu contextMenu)
+    {
+        contextMenu.AddItem("Remove VideoGap", () => RemoveVideoGap());
+    }
+
+    private void RemoveVideoGap()
+    {
+        setVideoGapAction.ExecuteAndNotify(0);
+        uiManager.CreateNotification("VideoGap reset to 0");
+    }
+}

--- a/UltraStar Play/Assets/Scenes/SongEditor/VideoArea/VideoAreaContextMenuHandler.cs.meta
+++ b/UltraStar Play/Assets/Scenes/SongEditor/VideoArea/VideoAreaContextMenuHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 924b795a7d5f335468e9626fea51a04c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### What does this PR do?

- Change VideoGap in song editor via drag gesture on the VideoArea.
- Therefore, refactored NoteAreaDragHandler into general DragHandler scripts
- The VideoGap can be reset via ContextMenu.
- The current VideoGap is shown as text at the mouse position while dragging.
- fix saving a song with negative VideoGap

### Closes Issue(s)

#119 
