### PR TITLE
improvements for mobile devices, fault tolerant song folder scanning

### DIFF
--- a/UltraStar Play/Assets/Common/Model/SettingsManager.cs
+++ b/UltraStar Play/Assets/Common/Model/SettingsManager.cs
@@ -14,8 +14,6 @@ public class SettingsManager : MonoBehaviour
         }
     }
 
-    private readonly string settingsPath = "Settings.json";
-
     // The settings field is static to persist it across scene changes.
     // The SettingsManager is meant to be used as a singleton, such that this static field should not be a problem.
     private static Settings settings;
@@ -56,16 +54,17 @@ public class SettingsManager : MonoBehaviour
     public void Save()
     {
         string json = JsonConverter.ToJson(Settings, true);
-        File.WriteAllText(settingsPath, json);
+        File.WriteAllText(SettingsPath(), json);
     }
 
     public void Reload()
     {
         using (new DisposableStopwatch("Loading the settings took <millis> ms"))
         {
+            string settingsPath = SettingsPath();
             if (!File.Exists(settingsPath))
             {
-                UnityEngine.Debug.LogWarning("Settings file not found. Creating default settings.");
+                UnityEngine.Debug.LogWarning($"Settings file not found. Creating default settings at {settingsPath}.");
                 settings = new Settings();
                 Save();
                 return;
@@ -74,5 +73,10 @@ public class SettingsManager : MonoBehaviour
             settings = JsonConverter.FromJson<Settings>(fileContent);
             nonStaticSettings = settings;
         }
+    }
+
+    public string SettingsPath()
+    {
+        return Path.Combine(Application.persistentDataPath, "Settings.json");
     }
 }

--- a/UltraStar Play/Assets/Common/Model/Song/SongMeta.cs
+++ b/UltraStar Play/Assets/Common/Model/Song/SongMeta.cs
@@ -79,51 +79,17 @@ public class SongMeta
         Encoding encoding
     )
     {
-        // C# 4.0 does not support the 'nameof' keyword, hence the strings
-        if (directory == null)
-        {
-            throw new ArgumentNullException("directory");
-        }
-        if (filename == null)
-        {
-            throw new ArgumentNullException("filename");
-        }
-        if (songHash == null)
-        {
-            throw new ArgumentNullException("songHash");
-        }
-        if (artist == null)
-        {
-            throw new ArgumentNullException("artist");
-        }
-        if (mp3 == null)
-        {
-            throw new ArgumentNullException("mp3");
-        }
-        if (title == null)
-        {
-            throw new ArgumentNullException("title");
-        }
-        if (voiceNames == null)
-        {
-            throw new ArgumentNullException("voiceNames");
-        }
-        if (encoding == null)
-        {
-            throw new ArgumentNullException("encoding");
-        }
+        Directory = directory ?? throw new ArgumentNullException("directory");
+        Filename = filename ?? throw new ArgumentNullException("filename");
+        SongHash = songHash ?? throw new ArgumentNullException("songHash");
 
-        Directory = directory;
-        Filename = filename;
-        SongHash = songHash;
-		
-        Artist = artist;
+        Artist = artist ?? throw new ArgumentNullException("artist");
         Bpm = bpm;
-        Mp3 = mp3;
-        Title = title;
+        Mp3 = mp3 ?? throw new ArgumentNullException("mp3");
+        Title = title ?? throw new ArgumentNullException("title");
 
-        this.voiceNames = voiceNames;
-        Encoding = encoding;
+        this.voiceNames = voiceNames ?? throw new ArgumentNullException("voiceNames");
+        Encoding = encoding ?? throw new ArgumentNullException("encoding");
 
         // set some defaults that we could not set otherwise
         Gap = 0;

--- a/UltraStar Play/Assets/Common/Model/SongMetaManager.cs
+++ b/UltraStar Play/Assets/Common/Model/SongMetaManager.cs
@@ -101,8 +101,15 @@ public class SongMetaManager : MonoBehaviour
             List<string> songDirs = SettingsManager.Instance.Settings.GameSettings.songDirs;
             foreach (string songDir in songDirs)
             {
-                List<string> txtFilesInSongDir = scannerTxt.GetFiles(songDir);
-                txtFiles.AddRange(txtFilesInSongDir);
+                try
+                {
+                    List<string> txtFilesInSongDir = scannerTxt.GetFiles(songDir);
+                    txtFiles.AddRange(txtFilesInSongDir);
+                }
+                catch (Exception ex)
+                {
+                    Debug.LogException(ex);
+                }
             }
             SongsFound = txtFiles.Count;
             Debug.Log($"Found {SongsFound} songs in {songDirs.Count} configured song directories");

--- a/UltraStar Play/Assets/Common/Model/StatsManager.cs
+++ b/UltraStar Play/Assets/Common/Model/StatsManager.cs
@@ -8,8 +8,6 @@ using UnityEngine;
 [Serializable]
 public class StatsManager : MonoBehaviour
 {
-    private readonly string databasePath = "Database.json";
-
     private static Statistics statistics;
     public Statistics Statistics
     {
@@ -33,20 +31,21 @@ public class StatsManager : MonoBehaviour
 
     public void Save()
     {
-         Debug.Log("Writing database");
+        Debug.Log("Writing database");
         //Update the total play time before saving
         statistics.UpdateTotalPlayTime();
 
         string json = JsonConverter.ToJson(Statistics, true);
-        File.WriteAllText(databasePath, json);
+        File.WriteAllText(DatabasePath(), json);
     }
 
     public void Reload()
     {
+        string databasePath = DatabasePath();
         Debug.Log("Reloading StatsManager");
         if (!File.Exists(databasePath))
         {
-            Debug.LogWarning("Database file not found. Initializing new database.");
+            Debug.LogWarning($"Database file not found. Creating new database at {databasePath}.");
             statistics = new Statistics();
             Save();
             return;
@@ -54,5 +53,10 @@ public class StatsManager : MonoBehaviour
 
         string fileContent = File.ReadAllText(databasePath);
         statistics = JsonConverter.FromJson<Statistics>(fileContent);
+    }
+
+    public string DatabasePath()
+    {
+        return Path.Combine(Application.persistentDataPath, "Database.json");
     }
 }

--- a/UltraStar Play/Assets/Scenes/Loading/LoadingSceneController.cs
+++ b/UltraStar Play/Assets/Scenes/Loading/LoadingSceneController.cs
@@ -5,6 +5,9 @@ public class LoadingSceneController : MonoBehaviour
 
     void Start()
     {
+        // Keep mobile devices from turning off the screen while the game is running.
+        Screen.sleepTimeout = (int)0f;
+        Screen.sleepTimeout = SleepTimeout.NeverSleep;
         // The settings are loaded on access.
         string jsonSettings = JsonConverter.ToJson(SettingsManager.Instance.Settings, true);
         Debug.Log("loaded settings:" + jsonSettings);

--- a/UltraStar Play/Assets/Scenes/Loading/LoadingSceneController.cs
+++ b/UltraStar Play/Assets/Scenes/Loading/LoadingSceneController.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using System.Collections;
+using UnityEngine;
 
 public class LoadingSceneController : MonoBehaviour
 {
@@ -26,7 +27,7 @@ public class LoadingSceneController : MonoBehaviour
         // it might be useful to continue via button.
         if (Input.anyKeyDown)
         {
-            FinishScene();
+            StartCoroutine(FinishAfterDelay(2));
         }
     }
 
@@ -35,4 +36,10 @@ public class LoadingSceneController : MonoBehaviour
         SceneNavigator.Instance.LoadScene(EScene.MainScene);
     }
 
+    private IEnumerator FinishAfterDelay(float delay)
+    {
+        // Wait delay in case loading just didn't finish yet.
+        yield return new WaitForSeconds(delay);
+        FinishScene();
+    }
 }

--- a/UltraStar Play/Assets/Scenes/SongEditor/SongEditorSceneController.cs
+++ b/UltraStar Play/Assets/Scenes/SongEditor/SongEditorSceneController.cs
@@ -270,7 +270,7 @@ public class SongEditorSceneController : MonoBehaviour, IBinder, INeedInjection
         UiManager.Instance.CreateNotification("Created copy of original file");
     }
 
-    private void ContinueToSingScene()
+    public void ContinueToSingScene()
     {
         if (sceneData.PreviousSceneData is SingSceneData)
         {

--- a/UltraStar Play/Assets/Scenes/SongEditor/SongEditorSceneKeyboardController.cs
+++ b/UltraStar Play/Assets/Scenes/SongEditor/SongEditorSceneKeyboardController.cs
@@ -93,7 +93,14 @@ public class SongEditorSceneKeyboardController : MonoBehaviour, INeedInjection
         // Stop via Escape
         if (Input.GetKeyUp(KeyCode.Escape))
         {
-            songAudioPlayer.PauseAudio();
+            if (songAudioPlayer.IsPlaying)
+            {
+                songAudioPlayer.PauseAudio();
+            }
+            else
+            {
+                songEditorSceneController.ContinueToSingScene();
+            }
         }
 
         // Select all notes via Ctrl+A


### PR DESCRIPTION
### What does this PR do?
- store Settings.json and Database.json in Application.persistentDataPath (On many platforms, the folder which contains the executable is not writable)
- clean up / simplify some null checks in SongMeta.cs
- try catch scanning song folders, log exception and continue next folder
- keep mobile devices from turning off the screen while the game is running
- wait at least 2 seconds when the user presses a button in Loading Scene for game to load stuff
- support closing the SongEditor by pressing escape key

### Motivation
I tested UltraStar Play on my android phone and ran in a couple of issues. This PR fixes most of them.