### PR TITLE
download-dependencies.s: use -rf and -v instead --recursive --force a…

### DIFF
--- a/tools/download-dependencies/download-csharpsynthforunity.sh
+++ b/tools/download-dependencies/download-csharpsynthforunity.sh
@@ -4,7 +4,7 @@ old_dir=$(pwd)
 
 cd "../../UltraStar Play/Assets/Plugins"
 echo "Removing old CSharpSynthForUnity folder..."
-rm --recursive --force CSharpSynthForUnity
+rm -rf CSharpSynthForUnity
 mkdir CSharpSynthForUnity
 cd CSharpSynthForUnity
 
@@ -13,13 +13,13 @@ git init
 git remote add origin https://github.com/achimmihca/CSharpSynthForUnity.git
 git config core.sparsecheckout true
 echo "Assets/*" >> .git/info/sparse-checkout
-# commit from 2nd February 2020: 05d40843524537fe5159e277717a74f3f5720475
+# UltraStar-Play-subset is a dedicated branch for the UltraStar Play project
 git pull --depth=100 origin UltraStar-Play-subset
 git checkout UltraStar-Play-subset
 
 echo "Moving downloaded files to correct position for this project..."
-mv --verbose Assets/* ./
-rm --recursive ./Assets
+mv -v Assets/* ./
+rm -rf ./Assets
 
 cd "$old_dir"
 echo "Downloading CSharpSynthForUnity done"

--- a/tools/download-dependencies/download-csharpsynthforunity.sh
+++ b/tools/download-dependencies/download-csharpsynthforunity.sh
@@ -15,7 +15,8 @@ git config core.sparsecheckout true
 echo "Assets/*" >> .git/info/sparse-checkout
 # UltraStar-Play-subset is a dedicated branch for the UltraStar Play project
 git pull --depth=100 origin UltraStar-Play-subset
-git checkout UltraStar-Play-subset
+# Commit from 09 February 2020: 0bc2afbe88cceceac6d618d612f4aeeb8cfcecf0
+git checkout 0bc2afbe88cceceac6d618d612f4aeeb8cfcecf0
 
 echo "Moving downloaded files to correct position for this project..."
 mv -v Assets/* ./

--- a/tools/download-dependencies/download-fullserializer.sh
+++ b/tools/download-dependencies/download-fullserializer.sh
@@ -4,7 +4,7 @@ old_dir=$(pwd)
 
 cd "../../UltraStar Play/Assets/Plugins"
 echo "Removing old FullSerializer folder..."
-rm --recursive --force FullSerializer
+rm -rf FullSerializer
 mkdir FullSerializer
 cd FullSerializer
 
@@ -18,8 +18,8 @@ git pull --depth=100 origin master
 git checkout c01db302f337205696585daa72e7d7baea922e44
 
 echo "Moving downloaded files to correct position for this project..."
-mv --verbose Assets/FullSerializer/* ./
-rm --recursive ./Assets
+mv -v Assets/FullSerializer/* ./
+rm -rf ./Assets
 
 cd "$old_dir"
 echo "Downloading FullSerializer done"

--- a/tools/download-dependencies/download-leantween.sh
+++ b/tools/download-dependencies/download-leantween.sh
@@ -4,7 +4,7 @@ old_dir=$(pwd)
 
 cd "../../UltraStar Play/Assets/Plugins"
 echo "Removing old LeanTween folder..."
-rm --recursive --force LeanTween
+rm -rf LeanTween
 mkdir LeanTween
 cd LeanTween
 
@@ -22,8 +22,8 @@ git pull --depth=100 origin master
 git checkout f387a18039f1eae62ab3e0a706c3e1002a4dcb22
 
 echo "Moving downloaded files to correct position for this project..."
-mv --verbose ./Assets/LeanTween/* ./
-rm --recursive ./Assets
+mv -v ./Assets/LeanTween/* ./
+rm -rf ./Assets
 
 cd "$old_dir"
 echo "Downloading LeanTween done"

--- a/tools/download-dependencies/download-nlayer.sh
+++ b/tools/download-dependencies/download-nlayer.sh
@@ -4,7 +4,7 @@ old_dir=$(pwd)
 
 cd "../../UltraStar Play/Assets/Plugins"
 echo "Removing old NLayer folder..."
-rm --recursive --force NLayer
+rm -rf NLayer
 mkdir NLayer
 cd NLayer
 
@@ -18,8 +18,8 @@ git pull --depth=100 origin master
 git checkout 51ca3ec1304f0e2bbaa3cadca69013f4af8ae6f1
 
 echo "Moving downloaded files to correct position for this project..."
-mv --verbose NLayer/* ./
-rm --recursive ./NLayer
+mv -v NLayer/* ./
+rm -rf ./NLayer
 
 cd "$old_dir"
 echo "Downloading NLayer done"

--- a/tools/download-dependencies/download-unirx.sh
+++ b/tools/download-dependencies/download-unirx.sh
@@ -4,7 +4,7 @@ old_dir=$(pwd)
 
 cd "../../UltraStar Play/Assets/Plugins"
 echo "Removing old UniRx folder..."
-rm --recursive --force UniRx
+rm -rf UniRx
 mkdir UniRx
 cd UniRx
 
@@ -19,8 +19,8 @@ git pull --depth=100 origin master
 git checkout 66205df49631860dd8f7c3314cb518b54c944d30
 
 echo "Moving downloaded files to correct position for this project..."
-mv --verbose Assets/Plugins/UniRx/* ./
-rm --recursive ./Assets
+mv -v Assets/Plugins/UniRx/* ./
+rm -rf ./Assets
 
 cd "$old_dir"
 echo "Downloading UniRx done"


### PR DESCRIPTION
### What does this PR do?

- download-dependencies.s: use -rf and -v instead --recursive --force and --verbose to be compatible with other shells

### Motivation

People using Mac have reported issues with the long form of the arguments