### PR TITLE
fixed ending singing exception when multiple players have same name

### DIFF
--- a/UltraStar Play/Assets/Scenes/SingingResults/SingingResultsSceneData.cs
+++ b/UltraStar Play/Assets/Scenes/SingingResults/SingingResultsSceneData.cs
@@ -6,7 +6,7 @@ public class SingingResultsSceneData : SceneData
 {
     public SongMeta SongMeta { get; set; }
     public List<PlayerProfile> PlayerProfiles { get; set; } = new List<PlayerProfile>();
-    private Dictionary<PlayerProfile, PlayerScoreData> playerScoreMap = new Dictionary<PlayerProfile, PlayerScoreData>();
+    private readonly Dictionary<PlayerProfile, PlayerScoreData> playerScoreMap = new Dictionary<PlayerProfile, PlayerScoreData>();
 
     public void AddPlayerScores(PlayerProfile profile, PlayerScoreData scoreData)
     {
@@ -14,7 +14,7 @@ public class SingingResultsSceneData : SceneData
         {
             PlayerProfiles.Add(profile);
         }
-        playerScoreMap.Add(profile, scoreData);
+        playerScoreMap[profile] = scoreData;
     }
 
     public PlayerScoreData GetPlayerScores(PlayerProfile playerProfile)


### PR DESCRIPTION
### What does this PR do?
Fixes the ArgumentException when there are multiple singing players with the same PlayerName and the SingResultScene was about to be shown.

### Motivation

````
ArgumentException: An item with the same key has already been added. Key: PlayerProfile
System.Collections.Generic.Dictionary`2[TKey,TValue].TryInsert (TKey key, TValue value, System.Collections.Generic.InsertionBehavior behavior) (at <567df3e0919241ba98db88bec4c6696f>:0)
System.Collections.Generic.Dictionary`2[TKey,TValue].Add (TKey key, TValue value) (at <567df3e0919241ba98db88bec4c6696f>:0)
SingingResultsSceneData.AddPlayerScores (PlayerProfile profile, SingingResultsSceneData+PlayerScoreData scoreData) (at Assets/Scenes/SingingResults/SingingResultsSceneData.cs:17)
SingSceneController.FinishScene () (at Assets/Scenes/Sing/SingSceneController.cs:258)
SingSceneKeyboardInputController.Update () (at Assets/Scenes/Sing/SingSceneKeyboardInputController.cs:38)
````
