### PR TITLE
Anst/improved pitch detection

### DIFF
--- a/UltraStar Play/Assets/Common/Audio/MidiUtils.cs
+++ b/UltraStar Play/Assets/Common/Audio/MidiUtils.cs
@@ -18,6 +18,11 @@ public static class MidiUtils
     // Black keys: C# = 1, D# = 3, F# = 6, G# = 8, A# = 10
     private static readonly int[] blackKeyRelativeMidiNotes = { 1, 3, 6, 8, 10 };
 
+    public static readonly double[] halftoneFrequencies = PrecalculateHalftoneFrequencies();
+
+    public static readonly double MaxHalftoneFrequency = halftoneFrequencies[halftoneFrequencies.Length - 1];
+    public static readonly double MinHalftoneFrequency = halftoneFrequencies[0];
+
     public static int GetOctave(int midiNote)
     {
         // 12: "C0"
@@ -95,5 +100,26 @@ public static class MidiUtils
     public static bool IsWhitePianoKey(int midiNote)
     {
         return whiteKeyRelativeMidiNotes.Contains(GetRelativePitch(midiNote));
+    }
+
+    public static double[] PrecalculateHalftoneFrequencies()
+    {
+        double[] noteFrequencies = new double[SingableNoteRange];
+        for (int index = 0; index < SingableNoteRange; index++)
+        {
+            float concertPitchOctaveOffset = ((MidiUtils.MidiNoteMin + index) - MidiUtils.MidiNoteConcertPitch) / 12f;
+            noteFrequencies[index] = MidiUtils.MidiNoteConcertPitchFrequency * Math.Pow(2f, concertPitchOctaveOffset);
+        }
+        return noteFrequencies;
+    }
+
+    public static int[] PrecalculateHalftoneDelays(double sampleRateHz)
+    {
+        int[] noteDelays = new int[SingableNoteRange];
+        for (int index = 0; index < SingableNoteRange; index++)
+        {
+            noteDelays[index] = Convert.ToInt32(sampleRateHz / halftoneFrequencies[index]);
+        }
+        return noteDelays;
     }
 }

--- a/UltraStar Play/Assets/Common/Audio/MidiUtils.cs
+++ b/UltraStar Play/Assets/Common/Audio/MidiUtils.cs
@@ -5,8 +5,8 @@ public static class MidiUtils
 {
     // There are 49 halftones in the singable audio spectrum,
     // namely C2 (midi note 36, which is 65.41 Hz) to C6 (midi note 84, which is 1046.5023 Hz).
-    public const int MidiNoteMin = 36;
-    public const int MidiNoteMax = 84;
+    public const int SingableNoteMin = 36;
+    public const int SingableNoteMax = 84;
     public const int SingableNoteRange = 49;
 
     // Concert pitch A4 (440 Hz)
@@ -17,11 +17,6 @@ public static class MidiUtils
     private static readonly int[] whiteKeyRelativeMidiNotes = { 0, 2, 4, 5, 7, 9, 11 };
     // Black keys: C# = 1, D# = 3, F# = 6, G# = 8, A# = 10
     private static readonly int[] blackKeyRelativeMidiNotes = { 1, 3, 6, 8, 10 };
-
-    public static readonly double[] halftoneFrequencies = PrecalculateHalftoneFrequencies();
-
-    public static readonly double MaxHalftoneFrequency = halftoneFrequencies[halftoneFrequencies.Length - 1];
-    public static readonly double MinHalftoneFrequency = halftoneFrequencies[0];
 
     public static int GetOctave(int midiNote)
     {
@@ -102,21 +97,21 @@ public static class MidiUtils
         return whiteKeyRelativeMidiNotes.Contains(GetRelativePitch(midiNote));
     }
 
-    public static double[] PrecalculateHalftoneFrequencies()
+    public static float[] PrecalculateHalftoneFrequencies(int noteMin, int noteRange)
     {
-        double[] noteFrequencies = new double[SingableNoteRange];
-        for (int index = 0; index < SingableNoteRange; index++)
+        float[] frequencies = new float[noteRange];
+        for (int index = 0; index < frequencies.Length; index++)
         {
-            float concertPitchOctaveOffset = ((MidiUtils.MidiNoteMin + index) - MidiUtils.MidiNoteConcertPitch) / 12f;
-            noteFrequencies[index] = MidiUtils.MidiNoteConcertPitchFrequency * Math.Pow(2f, concertPitchOctaveOffset);
+            float concertPitchOctaveOffset = ((noteMin + index) - MidiUtils.MidiNoteConcertPitch) / 12f;
+            frequencies[index] = (float)(MidiUtils.MidiNoteConcertPitchFrequency * Math.Pow(2f, concertPitchOctaveOffset));
         }
-        return noteFrequencies;
+        return frequencies;
     }
 
-    public static int[] PrecalculateHalftoneDelays(double sampleRateHz)
+    public static int[] PrecalculateHalftoneDelays(int sampleRateHz, float[] halftoneFrequencies)
     {
-        int[] noteDelays = new int[SingableNoteRange];
-        for (int index = 0; index < SingableNoteRange; index++)
+        int[] noteDelays = new int[halftoneFrequencies.Length];
+        for (int index = 0; index < halftoneFrequencies.Length; index++)
         {
             noteDelays[index] = Convert.ToInt32(sampleRateHz / halftoneFrequencies[index]);
         }

--- a/UltraStar Play/Assets/Common/Audio/Recording/AbstractAudioSamplesAnalyzer.cs
+++ b/UltraStar Play/Assets/Common/Audio/Recording/AbstractAudioSamplesAnalyzer.cs
@@ -14,10 +14,10 @@ abstract public class AbstractAudioSamplesAnalyzer : IAudioSamplesAnalyzer
         isEnabled = false;
     }
 
-    protected static bool IsAboveNoiseSuppressionThreshold(float[] audioSamplesBuffer, MicProfile micProfile)
+    protected static bool IsAboveNoiseSuppressionThreshold(float[] audioSamplesBuffer, int sampleCountToUse, MicProfile micProfile)
     {
         float minThreshold = micProfile.NoiseSuppression / 100f;
-        for (int index = 0; index < audioSamplesBuffer.Length; index++)
+        for (int index = 0; index < sampleCountToUse; index++)
         {
             if (Math.Abs(audioSamplesBuffer[index]) >= minThreshold)
             {

--- a/UltraStar Play/Assets/Common/Audio/Recording/AbstractAudioSamplesAnalyzer.cs
+++ b/UltraStar Play/Assets/Common/Audio/Recording/AbstractAudioSamplesAnalyzer.cs
@@ -1,0 +1,32 @@
+using System;
+
+abstract public class AbstractAudioSamplesAnalyzer : IAudioSamplesAnalyzer
+{
+    protected bool isEnabled;
+
+    public void Enable()
+    {
+        isEnabled = true;
+    }
+
+    public void Disable()
+    {
+        isEnabled = false;
+    }
+
+    protected static bool IsAboveNoiseSuppressionThreshold(float[] audioSamplesBuffer, MicProfile micProfile)
+    {
+        float minThreshold = micProfile.NoiseSuppression / 100f;
+        for (int index = 0; index < audioSamplesBuffer.Length; index++)
+        {
+            if (Math.Abs(audioSamplesBuffer[index]) >= minThreshold)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    abstract public PitchEvent ProcessAudioSamples(float[] audioSamplesBuffer, int samplesSinceLastFrame, MicProfile mic);
+
+}

--- a/UltraStar Play/Assets/Common/Audio/Recording/AbstractAudioSamplesAnalyzer.cs.meta
+++ b/UltraStar Play/Assets/Common/Audio/Recording/AbstractAudioSamplesAnalyzer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 88b8962d0c476e2439ba205044839e80
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UltraStar Play/Assets/Common/Audio/Recording/CamdAudioSamplesAnalyzer.cs
+++ b/UltraStar Play/Assets/Common/Audio/Recording/CamdAudioSamplesAnalyzer.cs
@@ -31,7 +31,7 @@ public class CamdAudioSamplesAnalyzer : AbstractAudioSamplesAnalyzer
     // The factor is used to reduce the normalizedError of a current candidate
     // when there is a candadite with the same halftone in the history.
     // This creates a tendency towards previously detected pitches.
-    public float HalftoneContinuationBias { get; set; } = 0;
+    public float HalftoneContinuationBias { get; set; }
 
     public CamdAudioSamplesAnalyzer(int sampleRateHz, int maxSampleLength)
     {
@@ -157,7 +157,7 @@ public class CamdAudioSamplesAnalyzer : AbstractAudioSamplesAnalyzer
             {
                 bestHistoryCandidate = historyCandidate;
             }
-        };
+        }
 
         // Do not consider the biased error when comparing best candidate from history.
         bestCandidate = (bestHistoryCandidate == null || bestCurrentCandidate.normalizedErrorWithBias < bestHistoryCandidate.normalizedError)
@@ -208,7 +208,7 @@ public class CamdAudioSamplesAnalyzer : AbstractAudioSamplesAnalyzer
     //   D_C(\tau)=\sum_{n=0}^{N-1}|x(mod(n+\tau, N)) - x(n)|
     // where \tau = halftoneDelay, n = index, N = samplesSinceLastFrame, x = sampleCountToUse
     // See: Equation (4) in http://www.utdallas.edu/~hxb076000/citing_papers/Muhammad%20Extended%20Average%20Magnitude%20Difference.pdf
-    private float[] CircularAverageMagnitudeDifference(float[] audioSamplesBuffer, int sampleCountToUse, float[] correlation)
+    private void CircularAverageMagnitudeDifference(float[] audioSamplesBuffer, int sampleCountToUse, float[] correlation)
     {
         // accumulate the magnitude differences for samples in AnalysisBuffer
         for (int halftone = 0; halftone < NumHalftones; halftone++)
@@ -220,8 +220,6 @@ public class CamdAudioSamplesAnalyzer : AbstractAudioSamplesAnalyzer
                 correlation[halftone] += (diff < 0) ? -diff : diff;
             }
         }
-        // return circular average magnitude difference
-        return correlation;
     }
 
     private void OnNoPitchDetected()

--- a/UltraStar Play/Assets/Common/Audio/Recording/MicrophonePitchTracker.cs
+++ b/UltraStar Play/Assets/Common/Audio/Recording/MicrophonePitchTracker.cs
@@ -9,10 +9,14 @@ public class MicrophonePitchTracker : MonoBehaviour
     // TODO: use 44100Hz (if supported) or fallback to default microphone sample rate
     private const int SampleRateHz = 44100;
 
+    // Longest period of singable notes (C2) requires 674 samples at 44100 Hz sample rate.
+    // Thus, 1024 samples should be sufficient.
+    private const int MaxSampleCountToUse = 1024;
+
     public bool playRecordedAudio;
 
     [Range(0, 1)]
-    public float halftoneContinuationBias = 0.2f;
+    public float halftoneContinuationBias = 0.1f;
 
     [ReadOnly]
     public string lastMidiNoteName;
@@ -91,7 +95,7 @@ public class MicrophonePitchTracker : MonoBehaviour
 
     private IAudioSamplesAnalyzer CreateAudioSamplesAnalyzer()
     {
-        CamdAudioSamplesAnalyzer camdAudioSamplesAnalyzer = new CamdAudioSamplesAnalyzer(SampleRateHz);
+        CamdAudioSamplesAnalyzer camdAudioSamplesAnalyzer = new CamdAudioSamplesAnalyzer(SampleRateHz, MaxSampleCountToUse);
         camdAudioSamplesAnalyzer.HalftoneContinuationBias = halftoneContinuationBias;
         return camdAudioSamplesAnalyzer;
     }
@@ -187,19 +191,18 @@ public class MicrophonePitchTracker : MonoBehaviour
         // In every frame, the mic buffer (which has a length of 1 second)
         // that was generated since the last frame has to be analyzed.
         int samplesSinceLastFrame = (int)(SampleRateHz * Time.deltaTime);
+        // Do not analyze more than necessary.
+        if (samplesSinceLastFrame > MaxSampleCountToUse)
+        {
+            samplesSinceLastFrame = MaxSampleCountToUse;
+        }
 
         // The new samples are coming in from the "right side" by Unity, i.e. the newest sample is at MicData.Length-1
         // The pitch detection lib analyzes its buffer from 0 to a given length (without the option for an offset).
         // Thus, we have to move the new samples in the mic buffer to the beginning of the buffer-to-be-analyzed.
         Array.Copy(MicData, SampleRateHz - samplesSinceLastFrame, PitchDetectionBuffer, 0, samplesSinceLastFrame);
 
-        // Clear the PitchDetection buffer that is not analyzed in this frame (this is not really needed).
-        for (int i = samplesSinceLastFrame; i < SampleRateHz; i++)
-        {
-            PitchDetectionBuffer[i] = 0;
-        }
-
-        ApplyMicAmplification(samplesSinceLastFrame);
+        ApplyMicAmplification(PitchDetectionBuffer, samplesSinceLastFrame);
 
         // Detect the pitch of the sample.
         PitchEvent pitchEvent = audioSamplesAnalyzer.ProcessAudioSamples(PitchDetectionBuffer, samplesSinceLastFrame, micProfile);
@@ -208,7 +211,7 @@ public class MicrophonePitchTracker : MonoBehaviour
         pitchEventStream.OnNext(pitchEvent);
     }
 
-    private void ApplyMicAmplification(int samplesSinceLastFrame)
+    private void ApplyMicAmplification(float[] buffer, int samplesSinceLastFrame)
     {
         if (micAmplifyMultiplier == 0)
         {
@@ -217,7 +220,7 @@ public class MicrophonePitchTracker : MonoBehaviour
         float newSample;
         for (int index = 0; index < samplesSinceLastFrame - 1; index++)
         {
-            newSample = PitchDetectionBuffer[index] * micAmplifyMultiplier;
+            newSample = buffer[index] * micAmplifyMultiplier;
             if (newSample > 1)
             {
                 newSample = 1;
@@ -226,7 +229,7 @@ public class MicrophonePitchTracker : MonoBehaviour
             {
                 newSample = -1;
             }
-            PitchDetectionBuffer[index] = newSample;
+            buffer[index] = newSample;
         }
     }
 

--- a/UltraStar Play/Assets/Common/Audio/Recording/MicrophonePitchTracker.cs
+++ b/UltraStar Play/Assets/Common/Audio/Recording/MicrophonePitchTracker.cs
@@ -11,6 +11,9 @@ public class MicrophonePitchTracker : MonoBehaviour
 
     public bool playRecordedAudio;
 
+    [Range(0, 1)]
+    public float halftoneContinuationBias = 0.2f;
+
     [ReadOnly]
     public string lastMidiNoteName;
     [ReadOnly]
@@ -81,8 +84,16 @@ public class MicrophonePitchTracker : MonoBehaviour
     void OnEnable()
     {
         audioSource = GetComponent<AudioSource>();
-        audioSamplesAnalyzer = new CamdAudioSamplesAnalyzer(SampleRateHz);
+
+        audioSamplesAnalyzer = CreateAudioSamplesAnalyzer();
         audioSamplesAnalyzer.Enable();
+    }
+
+    private IAudioSamplesAnalyzer CreateAudioSamplesAnalyzer()
+    {
+        CamdAudioSamplesAnalyzer camdAudioSamplesAnalyzer = new CamdAudioSamplesAnalyzer(SampleRateHz);
+        camdAudioSamplesAnalyzer.HalftoneContinuationBias = halftoneContinuationBias;
+        return camdAudioSamplesAnalyzer;
     }
 
     void OnDisable()
@@ -93,6 +104,11 @@ public class MicrophonePitchTracker : MonoBehaviour
 
     void Update()
     {
+        if (audioSamplesAnalyzer is CamdAudioSamplesAnalyzer)
+        {
+            (audioSamplesAnalyzer as CamdAudioSamplesAnalyzer).HalftoneContinuationBias = halftoneContinuationBias;
+        }
+
         UpdateMicrophoneAudioPlayback();
         UpdatePitchDetection();
     }

--- a/UltraStar Play/Assets/Common/Audio/Recording/MicrophonePitchTracker.prefab
+++ b/UltraStar Play/Assets/Common/Audio/Recording/MicrophonePitchTracker.prefab
@@ -44,8 +44,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: bf2308ba4a559d3488166d7bdad4d41d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  micDeviceName: Mikrofon (2- USB Microphone)
   playRecordedAudio: 1
+  halftoneContinuationBias: 0.1
+  lastMidiNoteName: 
+  lastMidiNote: 0
 --- !u!82 &6082356490043053463
 AudioSource:
   m_ObjectHideFlags: 0

--- a/UltraStar Play/Assets/Common/Model/Song/SongIssue/SongMetaAnalyzer.cs
+++ b/UltraStar Play/Assets/Common/Model/Song/SongIssue/SongMetaAnalyzer.cs
@@ -45,7 +45,7 @@ public static class SongMetaAnalyzer
             }
 
             // Find pitches outside of the singable range
-            if (note.MidiNote < MidiUtils.MidiNoteMin || note.MidiNote > MidiUtils.MidiNoteMax)
+            if (note.MidiNote < MidiUtils.SingableNoteMin || note.MidiNote > MidiUtils.SingableNoteMax)
             {
                 SongIssue issue = SongIssue.CreateWarning("Unusual pitch (human range is roughly from C2 to C6).", note.StartBeat, note.EndBeat);
                 result.Add(issue);

--- a/UltraStar Play/Assets/Common/Util/Collections/CircularBuffer.cs
+++ b/UltraStar Play/Assets/Common/Util/Collections/CircularBuffer.cs
@@ -1,0 +1,378 @@
+// See https://github.com/joaoportela/CircullarBuffer-CSharp
+/*
+License:
+----------------------------------------------------------------------------
+"THE BEER-WARE LICENSE" (Revision 42):
+Joao Portela wrote this file. As long as you retain this notice you
+can do whatever you want with this stuff. If we meet some day, and you think
+this stuff is worth it, you can buy me a beer in return.
+Joao Portela
+----------------------------------------------------------------------------
+*/
+using System;
+using System.Collections.Generic;
+using System.Collections;
+
+namespace CircularBuffer
+{
+    /// <inheritdoc/>
+    /// <summary>
+    /// Circular buffer.
+    /// 
+    /// When writing to a full buffer:
+    /// PushBack -> removes this[0] / Front()
+    /// PushFront -> removes this[Size-1] / Back()
+    /// 
+    /// this implementation is inspired by
+    /// http://www.boost.org/doc/libs/1_53_0/libs/circular_buffer/doc/circular_buffer.html
+    /// because I liked their interface.
+    /// </summary>
+    public class CircularBuffer<T> : IEnumerable<T>
+    {
+        private readonly T[] _buffer;
+
+        /// <summary>
+        /// The _start. Index of the first element in buffer.
+        /// </summary>
+        private int _start;
+
+        /// <summary>
+        /// The _end. Index after the last element in the buffer.
+        /// </summary>
+        private int _end;
+
+        /// <summary>
+        /// The _size. Buffer size.
+        /// </summary>
+        private int _size;
+
+        public CircularBuffer(int capacity)
+            : this(capacity, new T[] { })
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CircularBuffer{T}"/> class.
+        /// 
+        /// </summary>
+        /// <param name='capacity'>
+        /// Buffer capacity. Must be positive.
+        /// </param>
+        /// <param name='items'>
+        /// Items to fill buffer with. Items length must be less than capacity.
+        /// Suggestion: use Skip(x).Take(y).ToArray() to build this argument from
+        /// any enumerable.
+        /// </param>
+        public CircularBuffer(int capacity, T[] items)
+        {
+            if (capacity < 1)
+            {
+                throw new ArgumentException(
+                    "Circular buffer cannot have negative or zero capacity.", nameof(capacity));
+            }
+            if (items == null)
+            {
+                throw new ArgumentNullException(nameof(items));
+            }
+            if (items.Length > capacity)
+            {
+                throw new ArgumentException(
+                    "Too many items to fit circular buffer", nameof(items));
+            }
+
+            _buffer = new T[capacity];
+
+            Array.Copy(items, _buffer, items.Length);
+            _size = items.Length;
+
+            _start = 0;
+            _end = _size == capacity ? 0 : _size;
+        }
+
+        /// <summary>
+        /// Maximum capacity of the buffer. Elements pushed into the buffer after
+        /// maximum capacity is reached (IsFull = true), will remove an element.
+        /// </summary>
+        public int Capacity { get { return _buffer.Length; } }
+
+        public bool IsFull
+        {
+            get
+            {
+                return Size == Capacity;
+            }
+        }
+
+        public bool IsEmpty
+        {
+            get
+            {
+                return Size == 0;
+            }
+        }
+
+        public void Clear()
+        {
+            _size = 0;
+            _start = 0;
+            _end = _size == Capacity ? 0 : _size;
+        }
+
+        /// <summary>
+        /// Current buffer size (the number of elements that the buffer has).
+        /// </summary>
+        public int Size { get { return _size; } }
+
+        /// <summary>
+        /// Element at the front of the buffer - this[0].
+        /// </summary>
+        /// <returns>The value of the element of type T at the front of the buffer.</returns>
+        public T Front()
+        {
+            ThrowIfEmpty();
+            return _buffer[_start];
+        }
+
+        /// <summary>
+        /// Element at the back of the buffer - this[Size - 1].
+        /// </summary>
+        /// <returns>The value of the element of type T at the back of the buffer.</returns>
+        public T Back()
+        {
+            ThrowIfEmpty();
+            return _buffer[(_end != 0 ? _end : Capacity) - 1];
+        }
+
+        public T this[int index]
+        {
+            get
+            {
+                if (IsEmpty)
+                {
+                    throw new IndexOutOfRangeException(string.Format("Cannot access index {0}. Buffer is empty", index));
+                }
+                if (index >= _size)
+                {
+                    throw new IndexOutOfRangeException(string.Format("Cannot access index {0}. Buffer size is {1}", index, _size));
+                }
+                int actualIndex = InternalIndex(index);
+                return _buffer[actualIndex];
+            }
+            set
+            {
+                if (IsEmpty)
+                {
+                    throw new IndexOutOfRangeException(string.Format("Cannot access index {0}. Buffer is empty", index));
+                }
+                if (index >= _size)
+                {
+                    throw new IndexOutOfRangeException(string.Format("Cannot access index {0}. Buffer size is {1}", index, _size));
+                }
+                int actualIndex = InternalIndex(index);
+                _buffer[actualIndex] = value;
+            }
+        }
+
+        /// <summary>
+        /// Pushes a new element to the back of the buffer. Back()/this[Size-1]
+        /// will now return this element.
+        /// 
+        /// When the buffer is full, the element at Front()/this[0] will be 
+        /// popped to allow for this new element to fit.
+        /// </summary>
+        /// <param name="item">Item to push to the back of the buffer</param>
+        public void PushBack(T item)
+        {
+            if (IsFull)
+            {
+                _buffer[_end] = item;
+                Increment(ref _end);
+                _start = _end;
+            }
+            else
+            {
+                _buffer[_end] = item;
+                Increment(ref _end);
+                ++_size;
+            }
+        }
+
+        /// <summary>
+        /// Pushes a new element to the front of the buffer. Front()/this[0]
+        /// will now return this element.
+        /// 
+        /// When the buffer is full, the element at Back()/this[Size-1] will be 
+        /// popped to allow for this new element to fit.
+        /// </summary>
+        /// <param name="item">Item to push to the front of the buffer</param>
+        public void PushFront(T item)
+        {
+            if (IsFull)
+            {
+                Decrement(ref _start);
+                _end = _start;
+                _buffer[_start] = item;
+            }
+            else
+            {
+                Decrement(ref _start);
+                _buffer[_start] = item;
+                ++_size;
+            }
+        }
+
+        /// <summary>
+        /// Removes the element at the back of the buffer. Decreasing the 
+        /// Buffer size by 1.
+        /// </summary>
+        public void PopBack()
+        {
+            ThrowIfEmpty("Cannot take elements from an empty buffer.");
+            Decrement(ref _end);
+            _buffer[_end] = default(T);
+            --_size;
+        }
+
+        /// <summary>
+        /// Removes the element at the front of the buffer. Decreasing the 
+        /// Buffer size by 1.
+        /// </summary>
+        public void PopFront()
+        {
+            ThrowIfEmpty("Cannot take elements from an empty buffer.");
+            _buffer[_start] = default(T);
+            Increment(ref _start);
+            --_size;
+        }
+
+        /// <summary>
+        /// Copies the buffer contents to an array, according to the logical
+        /// contents of the buffer (i.e. independent of the internal 
+        /// order/contents)
+        /// </summary>
+        /// <returns>A new array with a copy of the buffer contents.</returns>
+        public T[] ToArray()
+        {
+            T[] newArray = new T[Size];
+            int newArrayOffset = 0;
+            var segments = new ArraySegment<T>[2] { ArrayOne(), ArrayTwo() };
+            foreach (ArraySegment<T> segment in segments)
+            {
+                Array.Copy(segment.Array, segment.Offset, newArray, newArrayOffset, segment.Count);
+                newArrayOffset += segment.Count;
+            }
+            return newArray;
+        }
+
+        #region IEnumerable<T> implementation
+        public IEnumerator<T> GetEnumerator()
+        {
+            var segments = new ArraySegment<T>[2] { ArrayOne(), ArrayTwo() };
+            foreach (ArraySegment<T> segment in segments)
+            {
+                for (int i = 0; i < segment.Count; i++)
+                {
+                    yield return segment.Array[segment.Offset + i];
+                }
+            }
+        }
+        #endregion
+        #region IEnumerable implementation
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return (IEnumerator)GetEnumerator();
+        }
+        #endregion
+
+        private void ThrowIfEmpty(string message = "Cannot access an empty buffer.")
+        {
+            if (IsEmpty)
+            {
+                throw new InvalidOperationException(message);
+            }
+        }
+
+        /// <summary>
+        /// Increments the provided index variable by one, wrapping
+        /// around if necessary.
+        /// </summary>
+        /// <param name="index"></param>
+        private void Increment(ref int index)
+        {
+            if (++index == Capacity)
+            {
+                index = 0;
+            }
+        }
+
+        /// <summary>
+        /// Decrements the provided index variable by one, wrapping
+        /// around if necessary.
+        /// </summary>
+        /// <param name="index"></param>
+        private void Decrement(ref int index)
+        {
+            if (index == 0)
+            {
+                index = Capacity;
+            }
+            index--;
+        }
+
+        /// <summary>
+        /// Converts the index in the argument to an index in <code>_buffer</code>
+        /// </summary>
+        /// <returns>
+        /// The transformed index.
+        /// </returns>
+        /// <param name='index'>
+        /// External index.
+        /// </param>
+        private int InternalIndex(int index)
+        {
+            return _start + (index < (Capacity - _start) ? index : index - Capacity);
+        }
+
+        // doing ArrayOne and ArrayTwo methods returning ArraySegment<T> as seen here: 
+        // http://www.boost.org/doc/libs/1_37_0/libs/circular_buffer/doc/circular_buffer.html#classboost_1_1circular__buffer_1957cccdcb0c4ef7d80a34a990065818d
+        // http://www.boost.org/doc/libs/1_37_0/libs/circular_buffer/doc/circular_buffer.html#classboost_1_1circular__buffer_1f5081a54afbc2dfc1a7fb20329df7d5b
+        // should help a lot with the code.
+
+        #region Array items easy access.
+        // The array is composed by at most two non-contiguous segments, 
+        // the next two methods allow easy access to those.
+
+        private ArraySegment<T> ArrayOne()
+        {
+            if (IsEmpty)
+            {
+                return new ArraySegment<T>(new T[0]);
+            }
+            else if (_start < _end)
+            {
+                return new ArraySegment<T>(_buffer, _start, _end - _start);
+            }
+            else
+            {
+                return new ArraySegment<T>(_buffer, _start, _buffer.Length - _start);
+            }
+        }
+
+        private ArraySegment<T> ArrayTwo()
+        {
+            if (IsEmpty)
+            {
+                return new ArraySegment<T>(new T[0]);
+            }
+            else if (_start < _end)
+            {
+                return new ArraySegment<T>(_buffer, _end, 0);
+            }
+            else
+            {
+                return new ArraySegment<T>(_buffer, 0, _end);
+            }
+        }
+        #endregion
+    }
+}

--- a/UltraStar Play/Assets/Common/Util/Collections/CircularBuffer.cs.meta
+++ b/UltraStar Play/Assets/Common/Util/Collections/CircularBuffer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 41ec74e733c1f9b4f96ddfeb28650211
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UltraStar Play/Assets/Common/Util/Extensions/CollectionExtensions.cs
+++ b/UltraStar Play/Assets/Common/Util/Extensions/CollectionExtensions.cs
@@ -1,9 +1,25 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using CircularBuffer;
 
 public static class CollectionExtensions
 {
+    public static void ForEach<T>(this T[] arr, Action<T> action)
+    {
+        for (int i = 0; i < arr.Length; i++)
+        {
+            action(arr[i]);
+        }
+    }
+
+    public static void ForEach<T>(this CircularBuffer<T> circularBuffer, Action<T> action)
+    {
+        for (int i = 0; i < circularBuffer.Size; i++)
+        {
+            action(circularBuffer[i]);
+        }
+    }
 
     public static string ToCsv<T>(this IEnumerable<T> enumerable, string separator = ",", string prefix = "[", string suffix = "]")
     {

--- a/UltraStar Play/Assets/Editor/Tests/PitchDetectionTests.cs
+++ b/UltraStar Play/Assets/Editor/Tests/PitchDetectionTests.cs
@@ -29,7 +29,7 @@ public class PitchDetectionTests
             audioClip.GetData(samples, 0);
 
             // Analyze the samples
-            IAudioSamplesAnalyzer audioSamplesAnalyzer = new CamdAudioSamplesAnalyzer(audioClip.frequency);
+            IAudioSamplesAnalyzer audioSamplesAnalyzer = new CamdAudioSamplesAnalyzer(audioClip.frequency, 2048);
             audioSamplesAnalyzer.Enable();
             PitchEvent pitchEvent = audioSamplesAnalyzer.ProcessAudioSamples(samples, samples.Length, micProfile);
 

--- a/UltraStar Play/Assets/Scenes/SongEditor/NoteArea/NoteArea.cs
+++ b/UltraStar Play/Assets/Scenes/SongEditor/NoteArea/NoteArea.cs
@@ -78,7 +78,7 @@ public class NoteArea : MonoBehaviour, INeedInjection, IPointerEnterHandler, IPo
         // Initialize Viewport
         int x = 0;
         int width = 5000;
-        int y = MidiUtils.MidiNoteMin + (MidiUtils.SingableNoteRange / 4);
+        int y = MidiUtils.SingableNoteMin + (MidiUtils.SingableNoteRange / 4);
         int height = MidiUtils.SingableNoteRange / 2;
         SetViewport(x, y, width, height);
 

--- a/UltraStar Play/Assets/Scenes/SongEditor/SongEditorScene.unity
+++ b/UltraStar Play/Assets/Scenes/SongEditor/SongEditorScene.unity
@@ -3795,7 +3795,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 06a8d7203429bb2498842dab7573df6b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultSongName: Summer Wine
+  defaultSongName: Somewhere Over The Rainbow (Wonderful World)
   defaultSongNamePasteBin: 'Summer Wine
 
     EmptyTitle
@@ -6805,6 +6805,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   playRecordedAudio: 0
+  halftoneContinuationBias: 0.2
   lastMidiNoteName: 
   lastMidiNote: 0
 --- !u!82 &906383521
@@ -9612,7 +9613,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -7.5000305, y: -0.50000095}
+  m_AnchoredPosition: {x: -7.5000305, y: -0.5}
   m_SizeDelta: {x: -35, y: -13}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1243198119
@@ -12405,8 +12406,8 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 71010841}
   m_HandleRect: {fileID: 71010840}
   m_Direction: 2
-  m_Value: 0.9999984
-  m_Size: 0.9401706
+  m_Value: 0
+  m_Size: 0.9998907
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -15598,7 +15599,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0.00003599003}
+  m_AnchoredPosition: {x: 0, y: 0.0000019086046}
   m_SizeDelta: {x: 0, y: 318.58}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &2142613635


### PR DESCRIPTION
### What does this PR do?

Improve pitch detection accuracy and performance. Also a little bit refactoring.

Performance is improved by the following:
- use float array instead of double array
- do not call extenal method Math.Abs. This was unexpectedly a pretty big improvement, probably because no method stack needs to be generated with return value etc.
- upper limit for analyzed samples
    - There was a self-reinforcing negative performance loop: When FPS dropped once for whatever reason, then more samples where given to the pitch detection, which resulted in bad performance, which means more time per frame, which again means more samples to be analyzed.

Accuracy is improved by the following
**1 - Qualitative comparison of pitch candidates:**
- The calculated correlation can be considered as "error" or "distance" to the checked frequency. Thus, the smaller the error, the more likely the checked frequency matches. 0 error is a perfect match. On the other hand, a big error indicates that the frequency does not match.
- This info is now used to compare the probability of detected frequency candidates. If one candidate has a much smaller error than the rest, then it is clear that this is the best candidate. However, when there are multiple candidates with similar error, then it is not as clear which candidate actually matches the real frequency.
- This leads to a definition for a normalized error for a candidate C: nError(C) = error(C) / sum_error_of_all_candidates
- In the implementation, I take the 3 pitches with lowest error as candidates for this frame.
- Example 1: normalized errors (A4: 0.05, G4: 0.4, B4: 0.55) -> first candidate is clearly the best candidate
- Example 2: normalized error (A4: 0.31, G4: 0.39, B4: 0.4) -> it is not as clear which candidate actually matches
- Now, compare the current candidates together with a history of last best candidates. This prefers a well matching candidate over most recent candidates (this is why I think of it is a qualitative comparison).
- Example of current 3 candidates (index 0 to 2) and last 2 best candidates (index 3, 4): (A4: 0.21, G4: 0.22, B4: 0.3, G4: 0.07, G4: 0.2) -> Amongst the 3 current candidates it is not as clear which one matches best. However, the last best candidate has a significatly low error, which means it was a very likely match. Thus, G4 should be chosen in this frame. Note that the old pitch detection would have choosen A4.
- Finally, in the above example you can see that in the last 2 frames, G4 has been detected as pitch. This is another information that can be used to improve the pitch detection. In the implemenation this is considered via a bias towards recently detected pitches (halftoneContinuationBias). The normalized error is reduced a little for a current candidate when it has the halftone from a history candidate.

The qualitative comparison improves the pitch detection significantly. It replaces the previous median calculation of detected pitches. I needed to recalibrate the mic delay and it dropped from about 300ms to about 200ms. All in all, the delay and pitch detection feels much more similar to USDX now.

**2 - Ignore candidates of notes outside of singable note range**
- The pitch detection tends towards the pitch with the highest frequency when no real signal is given. For example, It always showed C6 when I had noise suppression at 0 and was not making any sounds.
- Thus, I extended the range of checked frequencies with one octave that is outside of the singable note range. If any of these pitches is detected as best candidate for this frame, then use the last detected candidate instead (if possible).

Ignoring notes outside the singable range made the pitch detection less "jumpy".

### Motivation

The YIN pitch detection's performance was not good enough. However, its best part IMO is the "probability" of the estimated pitch. It inspired me to the qualitative comparison of correlation values.

### More

I needed a circular buffer for the pitch candidate history. I took an existing implementation with liberal license from GitHub: https://github.com/joaoportela/CircullarBuffer-CSharp

### Additional Notes

This is the first of multiple PR with improvements. I had to track down various performance issues, but wanted to create different PR for these to make the review easier.

I also have a PR prepared that implements the idea from #113. You might want to wait before re-doing the score comparison with USDX until it is merged as well.