### PR TITLE
Anst/improved note recording and drawing

### DIFF
--- a/UltraStar Play/Assets/Common/UI/UiManager.cs
+++ b/UltraStar Play/Assets/Common/UI/UiManager.cs
@@ -38,6 +38,11 @@ public class UiManager : MonoBehaviour, INeedInjection
 
     private readonly List<Notification> notifications = new List<Notification>();
 
+    void Awake()
+    {
+        LeanTween.init(800);
+    }
+
     void Start()
     {
         notificationHeightInPixels = notificationPrefab.GetComponent<RectTransform>().rect.height;

--- a/UltraStar Play/Assets/Common/Util/DisposableStopwatch.cs
+++ b/UltraStar Play/Assets/Common/Util/DisposableStopwatch.cs
@@ -15,9 +15,9 @@ public class DisposableStopwatch : IDisposable
 
     // Logs the given text when the stopwatch is disposed.
     // Thereby, the placeholder <millis> will be replaced with the elapsed milliseconds.
-    public DisposableStopwatch(string textWithPlaceholders, bool startStopwatch = true)
+    public DisposableStopwatch(string textWithPlaceholders, bool startStopwatch = true, float logPeriodInSeconds = 0)
     {
-        action = (sw) => LogTextWithPlaceholders(sw, textWithPlaceholders);
+        action = (sw) => LogTextWithPlaceholders(sw, textWithPlaceholders, logPeriodInSeconds);
         CreateStopwatch(startStopwatch);
     }
 
@@ -36,10 +36,19 @@ public class DisposableStopwatch : IDisposable
         }
     }
 
-    private void LogTextWithPlaceholders(Stopwatch sw, string textWithPlaceholders)
+    private void LogTextWithPlaceholders(Stopwatch sw, string textWithPlaceholders, float logPeriodInSeconds)
     {
         string millis = sw.ElapsedMilliseconds.ToString();
         string logText = textWithPlaceholders.Replace("<millis>", millis);
-        UnityEngine.Debug.Log(logText);
+        if (logPeriodInSeconds <= 0)
+        {
+            // Log immediately
+            UnityEngine.Debug.Log(logText);
+        }
+        else
+        {
+            // Log every now and then the measured durations
+            LogUtils.LogFreqeuently(textWithPlaceholders, millis, logPeriodInSeconds);
+        }
     }
 }

--- a/UltraStar Play/Assets/Common/Util/LogUtils.cs
+++ b/UltraStar Play/Assets/Common/Util/LogUtils.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+public class LogUtils
+{
+    private static Dictionary<string, LogData> messagePrefixToLogDataMap = new Dictionary<string, LogData>();
+
+    // Logs a message every period.
+    // The message is constructed from a messagePrefix and dataPoints that are accumulated over the period.
+    // Logging a message every frame quickly gets confusing. This method overcomes this
+    // by logging every now and then the combined data from multiple frames.
+    public static void LogFreqeuently(string messagePrefix, object dataPoint, float periodInSeconds = 1)
+    {
+        if (!messagePrefixToLogDataMap.TryGetValue(messagePrefix, out LogData logData))
+        {
+            logData = new LogData();
+            logData.LastLogTimeInSeconds = Time.time;
+            messagePrefixToLogDataMap[messagePrefix] = logData;
+        }
+
+        logData.DataPointQueue.Add(dataPoint.ToString());
+
+        if (logData.LastLogTimeInSeconds + periodInSeconds < Time.time)
+        {
+            string dataPointsCsv = string.Join(", ", logData.DataPointQueue);
+            Debug.Log($"{messagePrefix} [{dataPointsCsv}]");
+            logData.DataPointQueue.Clear();
+            logData.LastLogTimeInSeconds = Time.time;
+        }
+    }
+
+    private class LogData
+    {
+        public List<string> DataPointQueue { get; private set; } = new List<string>();
+        public float LastLogTimeInSeconds { get; set; }
+    }
+}

--- a/UltraStar Play/Assets/Common/Util/LogUtils.cs.meta
+++ b/UltraStar Play/Assets/Common/Util/LogUtils.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9898849b838630f4ab593907860df3ff
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UltraStar Play/Assets/Scenes/Sing/DefaultSingSceneDataProvider.cs
+++ b/UltraStar Play/Assets/Scenes/Sing/DefaultSingSceneDataProvider.cs
@@ -45,12 +45,17 @@ public class DefaultSingSceneDataProvider : MonoBehaviour, IDefaultSceneDataProv
         // The default song meta is for debugging in the Unity editor.
         // A specific song is searched, so first wait for the scan to complete.
         SongMetaManager.Instance.WaitUntilSongScanFinished();
-        SongMeta defaultSongMeta = SongMetaManager.Instance.FindSongMeta(it => it.Title.Trim() == defaultSongName.Trim());
+        SongMeta defaultSongMeta = SongMetaManager.Instance.FindSongMeta(it => it.Title.Trim() == GetDefaultSongName());
         if (defaultSongMeta == null)
         {
-            Debug.LogWarning($"No song with title '{defaultSongName.Trim()}' was found. Using the first found song instead.");
+            Debug.LogWarning($"No song with title '{GetDefaultSongName()}' was found. Using the first found song instead.");
             return SongMetaManager.Instance.GetFirstSongMeta();
         }
         return defaultSongMeta;
+    }
+
+    private string GetDefaultSongName()
+    {
+        return defaultSongName.Trim();
     }
 }

--- a/UltraStar Play/Assets/Scenes/Sing/DefaultSingSceneDataProvider.cs
+++ b/UltraStar Play/Assets/Scenes/Sing/DefaultSingSceneDataProvider.cs
@@ -45,10 +45,10 @@ public class DefaultSingSceneDataProvider : MonoBehaviour, IDefaultSceneDataProv
         // The default song meta is for debugging in the Unity editor.
         // A specific song is searched, so first wait for the scan to complete.
         SongMetaManager.Instance.WaitUntilSongScanFinished();
-        SongMeta defaultSongMeta = SongMetaManager.Instance.FindSongMeta(it => it.Title == defaultSongName);
+        SongMeta defaultSongMeta = SongMetaManager.Instance.FindSongMeta(it => it.Title.Trim() == defaultSongName.Trim());
         if (defaultSongMeta == null)
         {
-            Debug.LogWarning($"No song with title {defaultSongName} was found. Using the first found song instead.");
+            Debug.LogWarning($"No song with title '{defaultSongName.Trim()}' was found. Using the first found song instead.");
             return SongMetaManager.Instance.GetFirstSongMeta();
         }
         return defaultSongMeta;

--- a/UltraStar Play/Assets/Scenes/Sing/DummySingers/ChangingOffsetSinger.cs
+++ b/UltraStar Play/Assets/Scenes/Sing/DummySingers/ChangingOffsetSinger.cs
@@ -10,17 +10,11 @@ public class ChangingOffsetSinger : AbstractDummySinger
 
     public override void UpdateSinging(double currentBeat)
     {
-        Sentence currentSentence = playerController?.GetDisplaySentence();
-        if (currentSentence == null)
-        {
-            return;
-        }
-
-        int currentMidiNote = 0;
-        Note noteAtCurrentBeat = PlayerNoteRecorder.GetNoteAtBeat(currentSentence, currentBeat);
+        Note noteAtCurrentBeat = GetNoteAtCurrentBeat(currentBeat);
+        PitchEvent pitchEvent = null;
         if (noteAtCurrentBeat != null)
         {
-            currentMidiNote = noteAtCurrentBeat.MidiNote + noteOffset;
+            pitchEvent = new PitchEvent(noteAtCurrentBeat.MidiNote + noteOffset);
         }
         else if (lastNote != null)
         {
@@ -28,7 +22,7 @@ public class ChangingOffsetSinger : AbstractDummySinger
             // (falling flank: now there is no note, but in last frame there was one)
             noteOffset = (noteOffset + 1) % 5;
         }
-        playerController.PlayerNoteRecorder.HandlePitchEvent(new PitchEvent(currentMidiNote));
+        playerController.PlayerNoteRecorder.HandlePitchEvent(pitchEvent);
 
         lastNote = noteAtCurrentBeat;
     }

--- a/UltraStar Play/Assets/Scenes/Sing/DummySingers/PerfectSinger.cs
+++ b/UltraStar Play/Assets/Scenes/Sing/DummySingers/PerfectSinger.cs
@@ -10,18 +10,12 @@ public class PerfectSinger : AbstractDummySinger
 
     public override void UpdateSinging(double currentBeat)
     {
-        Sentence currentSentence = playerController?.GetDisplaySentence();
-        if (currentSentence == null)
-        {
-            return;
-        }
-
-        int currentMidiNote = 0;
-        Note noteAtCurrentBeat = PlayerNoteRecorder.GetNoteAtBeat(currentSentence, currentBeat);
+        Note noteAtCurrentBeat = GetNoteAtCurrentBeat(currentBeat);
+        PitchEvent pitchEvent = null;
         if (noteAtCurrentBeat != null)
         {
-            currentMidiNote = noteAtCurrentBeat.MidiNote + offset;
+            pitchEvent = new PitchEvent(noteAtCurrentBeat.MidiNote + offset);
         }
-        playerController.PlayerNoteRecorder.HandlePitchEvent(new PitchEvent(currentMidiNote));
+        playerController.PlayerNoteRecorder.HandlePitchEvent(pitchEvent);
     }
 }

--- a/UltraStar Play/Assets/Scenes/Sing/DummySingers/StutterSinger.cs
+++ b/UltraStar Play/Assets/Scenes/Sing/DummySingers/StutterSinger.cs
@@ -6,22 +6,12 @@ public class StutterSinger : AbstractDummySinger
 {
     public override void UpdateSinging(double currentBeat)
     {
-        Sentence currentSentence = playerController?.GetDisplaySentence();
-        if (currentSentence == null)
+        Note noteAtCurrentBeat = GetNoteAtCurrentBeat(currentBeat);
+        PitchEvent pitchEvent = null;
+        if (noteAtCurrentBeat != null && Random.Range(0, 5) != 0)
         {
-            return;
+            pitchEvent = new PitchEvent(noteAtCurrentBeat.MidiNote + Random.Range(-3, 3));
         }
-
-        int currentMidiNote = Random.Range(33, 70);
-        Note noteAtCurrentBeat = PlayerNoteRecorder.GetNoteAtBeat(currentSentence, currentBeat);
-        if (noteAtCurrentBeat != null)
-        {
-            currentMidiNote = noteAtCurrentBeat.MidiNote + Random.Range(-3, 3);
-        }
-        if (Random.Range(0, 5) == 0)
-        {
-            currentMidiNote = 0;
-        }
-        playerController.PlayerNoteRecorder.HandlePitchEvent(new PitchEvent(currentMidiNote));
+        playerController.PlayerNoteRecorder.HandlePitchEvent(pitchEvent);
     }
 }

--- a/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerController.cs
+++ b/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerController.cs
@@ -139,14 +139,14 @@ public class PlayerController : MonoBehaviour, INeedInjection
         int micDelayInMillis = (MicProfile == null) ? 0 : MicProfile.DelayInMillis;
         double micDelayInBeats = BpmUtils.MillisecondInSongToBeatWithoutGap(songMeta, micDelayInMillis);
         double currentBeatConsideringMicDelay = (micDelayInBeats > 0) ? currentBeat - micDelayInBeats : currentBeat;
-        if (recordingSentenceIndex < sortedSentences.Count && currentBeatConsideringMicDelay >= GetRecordingSentence().LinebreakBeat)
+        // The last sentence in the song should be scored as soon as possible such that one can continue to the next scene without waiting for the song to end.
+        bool isOverLastRecordingSentence = (recordingSentenceIndex == sortedSentences.Count - 1) && currentBeatConsideringMicDelay >= GetRecordingSentence().MaxBeat;
+        if (isOverLastRecordingSentence
+            || (recordingSentenceIndex >= 0 && recordingSentenceIndex < sortedSentences.Count && currentBeatConsideringMicDelay >= GetRecordingSentence().LinebreakBeat))
         {
+            FinishRecordingSentence(recordingSentenceIndex);
             Sentence nextRecordingSentence = GetUpcomingSentenceForBeat(currentBeatConsideringMicDelay);
-            int nextRecordingSentenceIndex = sortedSentences.IndexOf(nextRecordingSentence);
-            if (nextRecordingSentenceIndex >= 0)
-            {
-                SetRecordingSentenceIndex(nextRecordingSentenceIndex);
-            }
+            recordingSentenceIndex = sortedSentences.IndexOf(nextRecordingSentence);
         }
     }
 
@@ -254,12 +254,6 @@ public class PlayerController : MonoBehaviour, INeedInjection
         }
     }
 
-    private void SetRecordingSentenceIndex(int newValue)
-    {
-        FinishRecordingSentence(recordingSentenceIndex);
-        recordingSentenceIndex = newValue;
-    }
-
     private void FinishRecordingSentence(int sentenceIndex)
     {
         PlayerNoteRecorder.OnSentenceEnded();
@@ -311,7 +305,7 @@ public class PlayerController : MonoBehaviour, INeedInjection
 
     private Sentence GetSentence(int index)
     {
-        Sentence sentence = (index < sortedSentences.Count) ? sortedSentences[index] : null;
+        Sentence sentence = (index >= 0 && index < sortedSentences.Count) ? sortedSentences[index] : null;
         return sentence;
     }
 

--- a/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerController.cs
+++ b/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerController.cs
@@ -227,9 +227,12 @@ public class PlayerController : MonoBehaviour, INeedInjection
         DisplayRecordedNote(recordedNote);
     }
 
-    public void OnRecordedNoteContinued(RecordedNote recordedNote)
+    public void OnRecordedNoteContinued(RecordedNote recordedNote, bool updateUi)
     {
-        DisplayRecordedNote(recordedNote);
+        if (updateUi)
+        {
+            DisplayRecordedNote(recordedNote);
+        }
     }
 
     private void CheckPerfectlySungNote(RecordedNote lastRecordedNote)
@@ -268,6 +271,7 @@ public class PlayerController : MonoBehaviour, INeedInjection
         }
 
         List<RecordedNote> recordedNotes = PlayerNoteRecorder.GetRecordedNotes(recordingSentence);
+        PlayerNoteRecorder.RemoveRecordedNotes(recordingSentence);
         SentenceRating sentenceRating = PlayerScoreController.CalculateScoreForSentence(recordingSentence, recordedNotes);
         playerUiController.ShowTotalScore(PlayerScoreController.TotalScore);
         if (sentenceRating != null)
@@ -324,14 +328,6 @@ public class PlayerController : MonoBehaviour, INeedInjection
     {
         Sentence result = Voice.Sentences
             .Where(sentence => currentBeat < sentence.LinebreakBeat)
-            .FirstOrDefault();
-        return result;
-    }
-
-    public Sentence GetSentenceForBeat(double currentBeat)
-    {
-        Sentence result = Voice.Sentences
-            .Where(sentence => sentence.MinBeat <= currentBeat && currentBeat <= sentence.MaxBeat)
             .FirstOrDefault();
         return result;
     }

--- a/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerNoteRecorder.cs
+++ b/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerNoteRecorder.cs
@@ -40,6 +40,15 @@ public class PlayerNoteRecorder : MonoBehaviour, INeedInjection, IInjectionFinis
 
     private double lastBeatWithPitchEvent;
 
+    // The joker is used to cancel a mistake in continued singing.
+    // The joker is earned for continued singing of the correct pitch.
+    private int availableJokerCount;
+    private const int MaxJokerCount = 1;
+
+    // For debugging only: see how many jokers have been used in the inspector
+    [ReadOnly]
+    public int usedJokerCount;
+
     public void OnInjectionFinished()
     {
         roundingDistance = playerProfile.Difficulty.GetRoundingDistance();
@@ -87,6 +96,11 @@ public class PlayerNoteRecorder : MonoBehaviour, INeedInjection, IInjectionFinis
         return recordedNotes;
     }
 
+    public void RemoveRecordedNotes(Sentence sentence)
+    {
+        sentenceToRecordedNotesMap.Remove(sentence);
+    }
+
     public void OnSentenceEnded()
     {
         // Finish the last note.
@@ -108,15 +122,15 @@ public class PlayerNoteRecorder : MonoBehaviour, INeedInjection, IInjectionFinis
             int missedBeats = (int)(currentBeat - lastBeatWithPitchEvent);
             for (int i = 1; i <= missedBeats; i++)
             {
-                HandlePitchEvent(pitchEvent, lastBeatWithPitchEvent + i);
+                HandlePitchEvent(pitchEvent, lastBeatWithPitchEvent + i, false);
             }
         }
-        HandlePitchEvent(pitchEvent, currentBeat);
+        HandlePitchEvent(pitchEvent, currentBeat, true);
 
         lastBeatWithPitchEvent = currentBeat;
     }
 
-    private void HandlePitchEvent(PitchEvent pitchEvent, double currentBeat)
+    private void HandlePitchEvent(PitchEvent pitchEvent, double currentBeat, bool updateUi)
     {
         if (pitchEvent == null || pitchEvent.MidiNote <= 0)
         {
@@ -129,30 +143,61 @@ public class PlayerNoteRecorder : MonoBehaviour, INeedInjection, IInjectionFinis
         {
             if (lastRecordedNote != null)
             {
-                if (MidiUtils.GetRelativePitchDistance(lastRecordedNote.RoundedMidiNote, pitchEvent.MidiNote) <= roundingDistance)
+                bool isTargetNoteHit = MidiUtils.GetRelativePitchDistance(lastRecordedNote.TargetNote.MidiNote, pitchEvent.MidiNote) <= roundingDistance;
+                if (isTargetNoteHit && !lastRecordedNote.IsTargetNoteHit)
                 {
+                    // Jump from a wrong pitch to correct pitch.
+                    // Otherwise, the rounding could tend towards the wrong pitch instead of the correct pitch
+                    // when the player starts a note with the wrong pitch.
+                    HandleRecordedNoteEnded(currentBeat);
+                    HandleRecordedNoteStarted(pitchEvent.MidiNote, currentBeat, updateUi);
+                }
+                else if (MidiUtils.GetRelativePitchDistance(lastRecordedNote.RoundedMidiNote, pitchEvent.MidiNote) <= roundingDistance)
+                {
+                    // Earned a joker for continued correct singing.
+                    if (lastRecordedNote.IsTargetNoteHit && availableJokerCount < MaxJokerCount)
+                    {
+                        availableJokerCount++;
+                    }
+
                     // Continue singing on same pitch
-                    HandleRecordedNoteContinued(currentBeat);
+                    HandleRecordedNoteContinued(pitchEvent.MidiNote, currentBeat, updateUi);
                 }
                 else
                 {
-                    // Continue singing on different pitch. Finish the last recorded note.
-                    HandleRecordedNoteEnded(currentBeat);
+                    // Changed pitch while singing.
+                    if (!isTargetNoteHit
+                        && lastRecordedNote.IsTargetNoteHit
+                        && availableJokerCount > 0)
+                    {
+                        // Because of the joker, this beat is still counted as correct although it is not. The joker is gone.
+                        availableJokerCount--;
+                        usedJokerCount++;
+                        HandleRecordedNoteContinued(lastRecordedNote.RecordedMidiNote, currentBeat, updateUi);
+                    }
+                    else
+                    {
+                        // Continue singing on different pitch.
+                        HandleRecordedNoteEnded(currentBeat);
+                        HandleRecordedNoteStarted(pitchEvent.MidiNote, currentBeat, updateUi);
+                    }
                 }
             }
-
-            // The lastRecordedNote could be ended above, so the following null check is not redundant.
-            if (lastRecordedNote == null && currentBeat >= nextNoteStartBeat)
+            else
             {
-                // Start singing of a new note
-                HandleRecordedNoteStarted(pitchEvent.MidiNote, currentBeat);
+                HandleRecordedNoteStarted(pitchEvent.MidiNote, currentBeat, updateUi);
             }
         }
     }
 
-    private void HandleRecordedNoteStarted(int midiNote, double currentBeat)
+    private void HandleRecordedNoteStarted(int midiNote, double currentBeat, bool updateUi)
     {
-        Sentence currentSentence = playerController.GetSentenceForBeat(currentBeat);
+        if (currentBeat < nextNoteStartBeat)
+        {
+            return;
+        }
+
+        Sentence currentSentence = playerController.GetRecordingSentence();
 
         // Only accept recorded notes where a note is expected in the song
         Note noteAtCurrentBeat = GetNoteAtBeat(currentSentence, currentBeat);
@@ -161,16 +206,18 @@ public class PlayerNoteRecorder : MonoBehaviour, INeedInjection, IInjectionFinis
             return;
         }
 
-        // If the last note ended at the start of the new note, then continue using the last ended note.
+        // If the last note ended at the start of the new note and can be further extended,
+        // then continue using the last ended note.
         int roundedMidiNote = GetRoundedMidiNoteForRecordedNote(noteAtCurrentBeat, midiNote);
         double startBeat = Math.Floor(currentBeat);
         if (lastEndedNote != null
             && lastEndedNote.Sentence == currentSentence
             && lastEndedNote.EndBeat == startBeat
-            && lastEndedNote.RoundedMidiNote == roundedMidiNote)
+            && lastEndedNote.RoundedMidiNote == roundedMidiNote
+            && lastEndedNote.TargetNote.EndBeat > lastEndedNote.EndBeat)
         {
             lastRecordedNote = lastEndedNote;
-            HandleRecordedNoteContinued(currentBeat);
+            HandleRecordedNoteContinued(midiNote, currentBeat, updateUi);
             return;
         }
 
@@ -184,7 +231,7 @@ public class PlayerNoteRecorder : MonoBehaviour, INeedInjection, IInjectionFinis
         AddRecordedNote(lastRecordedNote, currentSentence);
     }
 
-    private void HandleRecordedNoteContinued(double currentBeat)
+    private void HandleRecordedNoteContinued(int midiNote, double currentBeat, bool updateUi)
     {
         lastRecordedNote.EndBeat = currentBeat;
 
@@ -194,10 +241,12 @@ public class PlayerNoteRecorder : MonoBehaviour, INeedInjection, IInjectionFinis
             lastRecordedNote.EndBeat = lastRecordedNote.TargetNote.EndBeat;
             playerController.OnRecordedNoteEnded(lastRecordedNote);
             lastRecordedNote = null;
+
+            HandleRecordedNoteStarted(midiNote, currentBeat, updateUi);
         }
         else
         {
-            playerController.OnRecordedNoteContinued(lastRecordedNote);
+            playerController.OnRecordedNoteContinued(lastRecordedNote, updateUi);
         }
     }
 
@@ -217,6 +266,7 @@ public class PlayerNoteRecorder : MonoBehaviour, INeedInjection, IInjectionFinis
         playerController.OnRecordedNoteEnded(lastRecordedNote);
         lastEndedNote = lastRecordedNote;
         lastRecordedNote = null;
+        availableJokerCount = 0;
     }
 
     private int GetRoundedMidiNoteForRecordedNote(Note targetNote, int recordedMidiNote)

--- a/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerNoteRecorder.cs
+++ b/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerNoteRecorder.cs
@@ -132,59 +132,59 @@ public class PlayerNoteRecorder : MonoBehaviour, INeedInjection, IInjectionFinis
 
     private void HandlePitchEvent(PitchEvent pitchEvent, double currentBeat, bool updateUi)
     {
+        // Stop recording
         if (pitchEvent == null || pitchEvent.MidiNote <= 0)
         {
             if (lastRecordedNote != null)
             {
                 HandleRecordedNoteEnded(currentBeat);
             }
+            return;
+        }
+
+        // Start new recorded note
+        if(lastRecordedNote == null) {
+            HandleRecordedNoteStarted(pitchEvent.MidiNote, currentBeat, updateUi);
+            return;
+        }
+
+        // Continue or finish existing recorded note. Possibly starting new note to change pitch.
+        bool isTargetNoteHit = MidiUtils.GetRelativePitchDistance(lastRecordedNote.TargetNote.MidiNote, pitchEvent.MidiNote) <= roundingDistance;
+        if (isTargetNoteHit && !lastRecordedNote.IsTargetNoteHit)
+        {
+            // Jump from a wrong pitch to correct pitch.
+            // Otherwise, the rounding could tend towards the wrong pitch
+            // when the player starts a note with the wrong pitch.
+            HandleRecordedNoteEnded(currentBeat);
+            HandleRecordedNoteStarted(pitchEvent.MidiNote, currentBeat, updateUi);
+        }
+        else if (MidiUtils.GetRelativePitchDistance(lastRecordedNote.RoundedMidiNote, pitchEvent.MidiNote) <= roundingDistance)
+        {
+            // Earned a joker for continued correct singing.
+            if (lastRecordedNote.IsTargetNoteHit && availableJokerCount < MaxJokerCount)
+            {
+                availableJokerCount++;
+            }
+
+            // Continue singing on same pitch
+            HandleRecordedNoteContinued(pitchEvent.MidiNote, currentBeat, updateUi);
         }
         else
         {
-            if (lastRecordedNote != null)
+            // Changed pitch while singing.
+            if (!isTargetNoteHit
+                && lastRecordedNote.IsTargetNoteHit
+                && availableJokerCount > 0)
             {
-                bool isTargetNoteHit = MidiUtils.GetRelativePitchDistance(lastRecordedNote.TargetNote.MidiNote, pitchEvent.MidiNote) <= roundingDistance;
-                if (isTargetNoteHit && !lastRecordedNote.IsTargetNoteHit)
-                {
-                    // Jump from a wrong pitch to correct pitch.
-                    // Otherwise, the rounding could tend towards the wrong pitch instead of the correct pitch
-                    // when the player starts a note with the wrong pitch.
-                    HandleRecordedNoteEnded(currentBeat);
-                    HandleRecordedNoteStarted(pitchEvent.MidiNote, currentBeat, updateUi);
-                }
-                else if (MidiUtils.GetRelativePitchDistance(lastRecordedNote.RoundedMidiNote, pitchEvent.MidiNote) <= roundingDistance)
-                {
-                    // Earned a joker for continued correct singing.
-                    if (lastRecordedNote.IsTargetNoteHit && availableJokerCount < MaxJokerCount)
-                    {
-                        availableJokerCount++;
-                    }
-
-                    // Continue singing on same pitch
-                    HandleRecordedNoteContinued(pitchEvent.MidiNote, currentBeat, updateUi);
-                }
-                else
-                {
-                    // Changed pitch while singing.
-                    if (!isTargetNoteHit
-                        && lastRecordedNote.IsTargetNoteHit
-                        && availableJokerCount > 0)
-                    {
-                        // Because of the joker, this beat is still counted as correct although it is not. The joker is gone.
-                        availableJokerCount--;
-                        usedJokerCount++;
-                        HandleRecordedNoteContinued(lastRecordedNote.RecordedMidiNote, currentBeat, updateUi);
-                    }
-                    else
-                    {
-                        // Continue singing on different pitch.
-                        HandleRecordedNoteEnded(currentBeat);
-                        HandleRecordedNoteStarted(pitchEvent.MidiNote, currentBeat, updateUi);
-                    }
-                }
+                // Because of the joker, this beat is still counted as correct although it is not. The joker is gone.
+                availableJokerCount--;
+                usedJokerCount++;
+                HandleRecordedNoteContinued(lastRecordedNote.RecordedMidiNote, currentBeat, updateUi);
             }
             else
             {
+                // Continue singing on different pitch.
+                HandleRecordedNoteEnded(currentBeat);
                 HandleRecordedNoteStarted(pitchEvent.MidiNote, currentBeat, updateUi);
             }
         }

--- a/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerNoteRecorder.cs
+++ b/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerNoteRecorder.cs
@@ -143,14 +143,15 @@ public class PlayerNoteRecorder : MonoBehaviour, INeedInjection, IInjectionFinis
         }
 
         // Start new recorded note
-        if(lastRecordedNote == null) {
+        if (lastRecordedNote == null)
+        {
             HandleRecordedNoteStarted(pitchEvent.MidiNote, currentBeat, updateUi);
             return;
         }
 
         // Continue or finish existing recorded note. Possibly starting new note to change pitch.
-        bool isTargetNoteHit = MidiUtils.GetRelativePitchDistance(lastRecordedNote.TargetNote.MidiNote, pitchEvent.MidiNote) <= roundingDistance;
-        if (isTargetNoteHit && !lastRecordedNote.IsTargetNoteHit)
+        bool isTargetNoteHitNow = MidiUtils.GetRelativePitchDistance(lastRecordedNote.TargetNote.MidiNote, pitchEvent.MidiNote) <= roundingDistance;
+        if (isTargetNoteHitNow && !IsTargetNoteHit(lastRecordedNote))
         {
             // Jump from a wrong pitch to correct pitch.
             // Otherwise, the rounding could tend towards the wrong pitch
@@ -161,7 +162,7 @@ public class PlayerNoteRecorder : MonoBehaviour, INeedInjection, IInjectionFinis
         else if (MidiUtils.GetRelativePitchDistance(lastRecordedNote.RoundedMidiNote, pitchEvent.MidiNote) <= roundingDistance)
         {
             // Earned a joker for continued correct singing.
-            if (lastRecordedNote.IsTargetNoteHit && availableJokerCount < MaxJokerCount)
+            if (IsTargetNoteHit(lastRecordedNote) && availableJokerCount < MaxJokerCount)
             {
                 availableJokerCount++;
             }
@@ -172,8 +173,8 @@ public class PlayerNoteRecorder : MonoBehaviour, INeedInjection, IInjectionFinis
         else
         {
             // Changed pitch while singing.
-            if (!isTargetNoteHit
-                && lastRecordedNote.IsTargetNoteHit
+            if (!isTargetNoteHitNow
+                && IsTargetNoteHit(lastRecordedNote)
                 && availableJokerCount > 0)
             {
                 // Because of the joker, this beat is still counted as correct although it is not. The joker is gone.
@@ -338,5 +339,10 @@ public class PlayerNoteRecorder : MonoBehaviour, INeedInjection, IInjectionFinis
         }
         double currentBeat = BpmUtils.MillisecondInSongToBeat(songMeta, positionInMillis);
         return currentBeat;
+    }
+
+    private bool IsTargetNoteHit(RecordedNote recordedNote)
+    {
+        return recordedNote.TargetNote != null && recordedNote.TargetNote.MidiNote == recordedNote.RoundedMidiNote;
     }
 }

--- a/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerUiController/PlayerUi.prefab
+++ b/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerUiController/PlayerUi.prefab
@@ -698,7 +698,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &3176150518743041249
 RectTransform:
   m_ObjectHideFlags: 0
@@ -783,7 +783,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &641890770593803178
 RectTransform:
   m_ObjectHideFlags: 0

--- a/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerUiController/PlayerUiController.cs
+++ b/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerUiController/PlayerUiController.cs
@@ -49,11 +49,6 @@ public class PlayerUiController : MonoBehaviour
         currentBeatGridDisplayer?.DisplaySentence(currentSentence);
     }
 
-    public void RemoveAllDisplayedNotes()
-    {
-        sentenceDisplayer.RemoveAllDisplayedNotes();
-    }
-
     public void ShowSentenceRating(SentenceRating sentenceRating)
     {
         sentenceRatingDisplayer.ShowSentenceRating(sentenceRating);
@@ -76,10 +71,6 @@ public class PlayerUiController : MonoBehaviour
 
     public void CreatePerfectNoteEffect(Note perfectNote)
     {
-        UiNote uiNote = GetComponentsInChildren<UiNote>().Where(it => it.Note == perfectNote).FirstOrDefault();
-        if (uiNote != null)
-        {
-            uiNote.CreatePerfectNoteEffect();
-        }
+        sentenceDisplayer.CreatePerfectNoteEffect(perfectNote);
     }
 }

--- a/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerUiController/SentenceDisplayer.cs
+++ b/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerUiController/SentenceDisplayer.cs
@@ -71,6 +71,13 @@ public class SentenceDisplayer : MonoBehaviour
 
     public void DisplayRecordedNote(RecordedNote recordedNote)
     {
+        if (recordedNote.TargetNote.Sentence != displayedSentence)
+        {
+            // This is probably a recorded note from the previous sentence that is still continued because of the mic delay.
+            // Do not draw the recorded note, it is not in the displayed sentence.
+            return;
+        }
+
         // Try to update existing recorded notes.
         if (recordedNoteToUiRecordedNotesMap.TryGetValue(recordedNote, out List<UiRecordedNote> uiRecordedNotes))
         {

--- a/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerUiController/UiNotes/UiNote.cs
+++ b/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerUiController/UiNotes/UiNote.cs
@@ -18,12 +18,15 @@ public class UiNote : MonoBehaviour
     [InjectedInInspector]
     public ImageHueHelper imageHueHelper;
 
+    [InjectedInInspector]
+    public Text lyricsUiText;
+
     public Note Note { get; set; }
     public bool isGolden;
 
-    private RectTransform uiEffectsContainer;
+    public RectTransform RectTransform { get; private set; }
 
-    private RectTransform rectTransform;
+    private RectTransform uiEffectsContainer;
 
     private readonly List<StarParticle> stars = new List<StarParticle>();
 
@@ -34,9 +37,9 @@ public class UiNote : MonoBehaviour
         this.uiEffectsContainer = uiEffectsContainer;
     }
 
-    void Start()
+    void Awake()
     {
-        rectTransform = GetComponent<RectTransform>();
+        RectTransform = GetComponent<RectTransform>();
     }
 
     void Update()
@@ -102,7 +105,7 @@ public class UiNote : MonoBehaviour
     {
         // Create several particles. Longer notes require more particles because they have more space to fill.
         int starCount = stars.Count;
-        int targetStarCount = Mathf.Max(6, (int)rectTransform.rect.width / 10);
+        int targetStarCount = Mathf.Max(6, (int)RectTransform.rect.width / 10);
         if (starCount < targetStarCount)
         {
             CreateGoldenStar();
@@ -112,7 +115,7 @@ public class UiNote : MonoBehaviour
     private void CreateGoldenStar()
     {
         StarParticle star = Instantiate(goldenStarPrefab);
-        star.transform.SetParent(rectTransform);
+        star.transform.SetParent(RectTransform);
         RectTransform starRectTransform = star.GetComponent<RectTransform>();
         float anchorX = Random.Range(0f, 1f);
         float anchorY = Random.Range(0f, 1f);

--- a/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerUiController/UiNotes/UiNotePrefab.prefab
+++ b/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerUiController/UiNotes/UiNotePrefab.prefab
@@ -29,6 +29,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 8590359238081736742}
+  - {fileID: 8590359238897754698}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -55,6 +56,7 @@ MonoBehaviour:
     type: 3}
   image: {fileID: 8590359238081736741}
   imageHueHelper: {fileID: 3889450297425548421}
+  lyricsUiText: {fileID: 8590359238897754697}
   isGolden: 0
 --- !u!1 &8590359238081736743
 GameObject:
@@ -85,8 +87,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 8590359238897754698}
+  m_Children: []
   m_Father: {fileID: 8590359238075033077}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -159,7 +160,7 @@ GameObject:
   - component: {fileID: 8590359238897754696}
   - component: {fileID: 8590359238897754697}
   m_Layer: 0
-  m_Name: NoteName
+  m_Name: LyricsText
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -172,12 +173,12 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8590359238897754699}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 8590359238081736742}
-  m_RootOrder: 0
+  m_Father: {fileID: 8590359238075033077}
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}

--- a/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerUiController/UiNotes/UiRecordedNote.cs
+++ b/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerUiController/UiNotes/UiRecordedNote.cs
@@ -2,21 +2,33 @@
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
+using UniInject;
 
 public class UiRecordedNote : MonoBehaviour
 {
-    private ImageHueHelper imageHueHelper;
+    [InjectedInInspector]
+    public Text lyricsUiText;
+    [InjectedInInspector]
+    public ImageHueHelper imageHueHelper;
+
+    public RectTransform RectTransform { get; private set; }
+    public int MidiNote { get; set; }
 
     void Awake()
     {
-        imageHueHelper = GetComponentInChildren<ImageHueHelper>();
+        RectTransform = GetComponent<RectTransform>();
     }
 
     public void SetColorOfMicProfile(MicProfile micProfile)
     {
         if (micProfile != null)
         {
-            imageHueHelper.SetHueByColor(micProfile.Color);
+            SetColor(micProfile.Color);
         }
+    }
+
+    public void SetColor(Color color)
+    {
+        imageHueHelper.SetHueByColor(color);
     }
 }

--- a/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerUiController/UiNotes/UiRecordedNotePrefab.prefab
+++ b/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerUiController/UiNotes/UiRecordedNotePrefab.prefab
@@ -29,6 +29,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 730526333788458355}
+  - {fileID: 2040862828101374607}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -49,6 +50,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d41efd84c6371e442bc11a68ccfcc4a2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  lyricsUiText: {fileID: 2846181495390017783}
+  imageHueHelper: {fileID: 996218955787764137}
 --- !u!1 &1473120825482942063
 GameObject:
   m_ObjectHideFlags: 0
@@ -78,8 +81,7 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 2040862828101374607}
+  m_Children: []
   m_Father: {fileID: 9030090544604440398}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -109,7 +111,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 2100000, guid: 6d7290ea574ff4d48bad8d35bfec9213, type: 2}
-  m_Color: {r: 1, g: 0.613512, b: 0, a: 1}
+  m_Color: {r: 0, g: 0, b: 0, a: 1}
   m_RaycastTarget: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
@@ -138,6 +140,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 85abb5276c45f2c4bb8146818e101049, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  hue: 0
+  hueAsColor: {r: 1, g: 0, b: 0, a: 1}
 --- !u!1 &7220638728962363615
 GameObject:
   m_ObjectHideFlags: 0
@@ -150,7 +154,7 @@ GameObject:
   - component: {fileID: 2511693166792069900}
   - component: {fileID: 2846181495390017783}
   m_Layer: 0
-  m_Name: NoteName
+  m_Name: LyricsText
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -163,12 +167,12 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7220638728962363615}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 730526333788458355}
-  m_RootOrder: 0
+  m_Father: {fileID: 9030090544604440398}
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}

--- a/UltraStar Play/Assets/Scenes/Sing/PlayerController/RecordedNote.cs
+++ b/UltraStar Play/Assets/Scenes/Sing/PlayerController/RecordedNote.cs
@@ -14,14 +14,6 @@ public class RecordedNote
     public Sentence Sentence { get; set; }
     public Note TargetNote { get; set; }
 
-    public bool IsTargetNoteHit
-    {
-        get
-        {
-            return TargetNote != null && TargetNote.MidiNote == RoundedMidiNote;
-        }
-    }
-
     public RecordedNote(int midiNote, double startBeat, double endBeat)
     {
         this.RecordedMidiNote = midiNote;

--- a/UltraStar Play/Assets/Scenes/Sing/PlayerController/RecordedNote.cs
+++ b/UltraStar Play/Assets/Scenes/Sing/PlayerController/RecordedNote.cs
@@ -14,6 +14,14 @@ public class RecordedNote
     public Sentence Sentence { get; set; }
     public Note TargetNote { get; set; }
 
+    public bool IsTargetNoteHit
+    {
+        get
+        {
+            return TargetNote != null && TargetNote.MidiNote == RoundedMidiNote;
+        }
+    }
+
     public RecordedNote(int midiNote, double startBeat, double endBeat)
     {
         this.RecordedMidiNote = midiNote;

--- a/UltraStar Play/Assets/Scenes/Sing/SingScene.unity
+++ b/UltraStar Play/Assets/Scenes/Sing/SingScene.unity
@@ -366,7 +366,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 04e8e8353cf7d75419d03321d0098a54, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultSongName: Hakuna matata
+  defaultSongName: Summer Wine (short)
   defaultSongNamePasteBin: "Summer Wine\r\nEmptyTitle\r\nMe And My Broken Heart\r\nSomewhere
     Over The Rainbow (Wonderful World)\r\nMarry You\r\nHakuna matata"
 --- !u!4 &242235910
@@ -656,11 +656,11 @@ MonoBehaviour:
   anchorMin: {x: 0, y: 0}
   anchorMax: {x: 0, y: 0}
   pivot: {x: 0.5, y: 0.5}
-  localPosition: {x: 493.5, y: 274, z: 0}
-  anchoredPosition: {x: 493.5, y: 274}
-  position: {x: 493.5, y: 274, z: 0}
-  sizeDelta: {x: 800, y: 444.17426}
-  size: {x: 800, y: 444.17426}
+  localPosition: {x: 494.5, y: 294.5, z: 0}
+  anchoredPosition: {x: 494.5, y: 294.5}
+  position: {x: 494.5, y: 294.5, z: 0}
+  sizeDelta: {x: 800, y: 476.44083}
+  size: {x: 800, y: 476.44083}
 --- !u!1 &475691986
 GameObject:
   m_ObjectHideFlags: 0
@@ -1051,7 +1051,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1832391155}
-  m_RootOrder: 17
+  m_RootOrder: 16
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &857926566
 MonoBehaviour:
@@ -1817,7 +1817,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6be2f30665fd64c47bd168248d708334, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  playerIndexToSimulate: 1
+  playerIndexToSimulate: 0
   maxOffset: 5
 --- !u!4 &1343358236
 Transform:
@@ -2208,6 +2208,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1133568350397856062, guid: 526f667f64d4f6949a1aa2bbba7ef376,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 17
       objectReference: {fileID: 0}
     - target: {fileID: 8992703894111156196, guid: 526f667f64d4f6949a1aa2bbba7ef376,
         type: 3}

--- a/UltraStar Play/Assets/Scenes/SongEditor/DefaultSongEditorSceneDataProvider.cs
+++ b/UltraStar Play/Assets/Scenes/SongEditor/DefaultSongEditorSceneDataProvider.cs
@@ -35,10 +35,10 @@ public class DefaultSongEditorSceneDataProvider : MonoBehaviour, IDefaultSceneDa
         // The default song meta is for debugging in the Unity editor.
         // A specific song is searched, so first wait for the scan to complete.
         SongMetaManager.Instance.WaitUntilSongScanFinished();
-        SongMeta defaultSongMeta = SongMetaManager.Instance.FindSongMeta(it => it.Title == defaultSongName);
+        SongMeta defaultSongMeta = SongMetaManager.Instance.FindSongMeta(it => it.Title == defaultSongName.Trim());
         if (defaultSongMeta == null)
         {
-            Debug.LogWarning($"No song with title {defaultSongName} was found. Using the first found song instead.");
+            Debug.LogWarning($"No song with title '{defaultSongName.Trim()}' was found. Using the first found song instead.");
             return SongMetaManager.Instance.GetFirstSongMeta();
         }
         return defaultSongMeta;

--- a/UltraStar Play/Assets/Scenes/SongEditor/DefaultSongEditorSceneDataProvider.cs
+++ b/UltraStar Play/Assets/Scenes/SongEditor/DefaultSongEditorSceneDataProvider.cs
@@ -35,12 +35,17 @@ public class DefaultSongEditorSceneDataProvider : MonoBehaviour, IDefaultSceneDa
         // The default song meta is for debugging in the Unity editor.
         // A specific song is searched, so first wait for the scan to complete.
         SongMetaManager.Instance.WaitUntilSongScanFinished();
-        SongMeta defaultSongMeta = SongMetaManager.Instance.FindSongMeta(it => it.Title == defaultSongName.Trim());
+        SongMeta defaultSongMeta = SongMetaManager.Instance.FindSongMeta(it => it.Title == GetDefaultSongName());
         if (defaultSongMeta == null)
         {
-            Debug.LogWarning($"No song with title '{defaultSongName.Trim()}' was found. Using the first found song instead.");
+            Debug.LogWarning($"No song with title '{GetDefaultSongName()}' was found. Using the first found song instead.");
             return SongMetaManager.Instance.GetFirstSongMeta();
         }
         return defaultSongMeta;
+    }
+
+    private string GetDefaultSongName()
+    {
+        return defaultSongName.Trim();
     }
 }

--- a/UltraStar Play/Assets/Scenes/SongEditor/EditorNote/EditorUiNotePrefab.prefab
+++ b/UltraStar Play/Assets/Scenes/SongEditor/EditorNote/EditorUiNotePrefab.prefab
@@ -391,7 +391,7 @@ GameObject:
   - component: {fileID: 7650775801032438272}
   - component: {fileID: 7650775801032438273}
   m_Layer: 0
-  m_Name: NoteName
+  m_Name: LyricsText
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0

--- a/UltraStar Play/Assets/Scenes/SongSelect/SongSelectSceneController.cs
+++ b/UltraStar Play/Assets/Scenes/SongSelect/SongSelectSceneController.cs
@@ -9,6 +9,9 @@ using UnityEngine.EventSystems;
 using System.Globalization;
 using System.Threading;
 
+// Disable warning about fields that are never assigned, their values are injected.
+#pragma warning disable CS0649
+
 public class SongSelectSceneController : MonoBehaviour, IOnHotSwapFinishedListener, INeedInjection, IBinder
 {
     public static SongSelectSceneController Instance


### PR DESCRIPTION
### What does this PR do?

Part two of improvements.
 - There was an exception because LeanTween did not have more handles for animating. It occured in a song with lots of golden notes, thus lots of golden start to animate. LeanTween.Init is used to double the amount of available handles.
- I am often logging stuff every frame, which is a lot of logs and difficult to read. The LogUtils.LogFrequently method helps me with this. You can accumulate data to be logged and log it once a second (for example).
- There is logic to handle a pitch event also for missed beats. However, drawing these missed beats is not necessary and is now skipped. This was another self-reinforcing performance drain because the more beats were skipped, the more needed to be drawn to catch up.
- An updated UiRecordedNote is now only position anew. Before, it was destroyed, re-instantiated, and then positioned.
- There were some GetComponentsInChildren calls for finding UiNotes and stuff in UiNotes that were not necessary. Some components (e.g. the Text for the lyrics) are set in the inspector instead now.
- a "joker" system for the note recording implements a simpler version of #113. For continued correct singing of beats, a joker is earned. This joker can be used to cancel a missing beat in continued singing. This also makes the pitch detection feel less "jumpy". In tests, I counted something between 60 to 100 jokers for me, which should be fine.

### Closes Issue(s)

#113

### Additional Notes

There is still a small PR in the queue with performance improvements for the video playback.
And another one for audio and video preview in song select.