### PR TITLE
Anst/note recording tweak

### DIFF
--- a/UltraStar Play/Assets/Common/Audio/Recording/CamdAudioSamplesAnalyzer.cs
+++ b/UltraStar Play/Assets/Common/Audio/Recording/CamdAudioSamplesAnalyzer.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -20,7 +20,7 @@ public class CamdAudioSamplesAnalyzer : AbstractAudioSamplesAnalyzer
     private readonly float[] correlation = new float[NumHalftones];
 
     private readonly CamdPitchCandidate[] currentCandidates = new CamdPitchCandidate[3];
-    private readonly CircularBuffer<CamdPitchCandidate> candidateHistory = new CircularBuffer<CamdPitchCandidate>(3);
+    private readonly CircularBuffer<CamdPitchCandidate> candidateHistory = new CircularBuffer<CamdPitchCandidate>(2);
 
     // The best candidate from the currentCandidates and candidateHistory
     private CamdPitchCandidate bestCandidate;

--- a/UltraStar Play/Assets/Common/Model/StatsManager.cs
+++ b/UltraStar Play/Assets/Common/Model/StatsManager.cs
@@ -34,13 +34,13 @@ public class StatsManager : MonoBehaviour
     {
         Debug.Log("Writing database");
         // Update the total play time before saving
-        statistics.UpdateTotalPlayTime();
+        Statistics.UpdateTotalPlayTime();
 
         // Do not pretty print json. The database is relatively big compared to the settings.
         // To view the JSON file, use an external viewer/formatter, for example a web browser or JSON Viewer plugin of Notepad++.
         string json = JsonConverter.ToJson(Statistics, false);
         File.WriteAllText(DatabasePath(), json);
-        statistics.IsDirty = false;
+        Statistics.IsDirty = false;
     }
 
     public void Reload()
@@ -67,7 +67,7 @@ public class StatsManager : MonoBehaviour
     void OnDisable()
     {
         // Save the statistics when necessary.
-        if (statistics.IsDirty)
+        if (statistics != null && statistics.IsDirty)
         {
             Debug.Log("Stats have changed. Saving stats");
             Save();

--- a/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerNoteRecorder.cs
+++ b/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerNoteRecorder.cs
@@ -48,6 +48,9 @@ public class PlayerNoteRecorder : MonoBehaviour, INeedInjection, IInjectionFinis
     // For debugging only: see how many jokers have been used in the inspector
     [ReadOnly]
     public int usedJokerCount;
+    // For debugging only: see how many times it was rounded to the target note because the pitch detection failed
+    [ReadOnly]
+    public int roundingBecausePitchDetectionFailedCount;
 
     public void OnInjectionFinished()
     {
@@ -275,6 +278,13 @@ public class PlayerNoteRecorder : MonoBehaviour, INeedInjection, IInjectionFinis
         if (targetNote.Type == ENoteType.Rap || targetNote.Type == ENoteType.RapGolden)
         {
             // Rap notes accept any noise as correct note.
+            return targetNote.MidiNote;
+        }
+        else if (recordedMidiNote < MidiUtils.SingableNoteMin || recordedMidiNote > MidiUtils.SingableNoteMax)
+        {
+            // The pitch detection can fail, which is the case when the detected pitch is outside of the singable note range.
+            // In this case, just assume that the player was singing correctly and round to the target note.
+            roundingBecausePitchDetectionFailedCount++;
             return targetNote.MidiNote;
         }
         else


### PR DESCRIPTION
### What does this PR do?

This is a tiny PR.

There are still cases where the audio analyzer will detect a pitch outside of the singable note range. This is clearly a fault on the technical side and punishing the player for it is unfair.
Thus, this PR changes the note recording in favor for the player if this happens.

Besides that, I reduced the history of the CamdAnalyzer a little because it felt unresponsive at times. However, this is purely subjective. In general, I am unsure of the overall quality of the pitch detection since I do not have any benchmarks. Sometimes it feels good, sometimes inferior to the USDX pitch detection.

Is USDX doing something different than the Camd analysis? What is the frame rate / analyzed buffer size in USDX? Are multiple measurings combined to a final result when there are multiple frames for a single beat?