### PR TITLE
Anst/overwrite settings from command line

### DIFF
--- a/UltraStar Play/Assets/Common/ApplicationManager.cs
+++ b/UltraStar Play/Assets/Common/ApplicationManager.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -11,6 +12,8 @@ public class ApplicationManager : MonoBehaviour
             return GameObjectUtils.FindComponentWithTag<ApplicationManager>("ApplicationManager");
         }
     }
+
+    public List<string> simulatedCommandLineArguments = new List<string>();
 
     [Range(5, 60)]
     public int targetFrameRate = 30;
@@ -26,6 +29,48 @@ public class ApplicationManager : MonoBehaviour
         if (Application.targetFrameRate != targetFrameRate)
         {
             Application.targetFrameRate = targetFrameRate;
+        }
+    }
+
+    public bool HasCommandLineArgument(string argumentName)
+    {
+        string[] args = GetCommandLineArguments();
+        for (int i = 0; i < args.Length; i++)
+        {
+            if (string.Equals(args[i], argumentName, StringComparison.InvariantCultureIgnoreCase))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public string GetCommandLineArgument(string argumentName)
+    {
+        string[] args = GetCommandLineArguments();
+        for (int i = 0; i < (args.Length - 1); i++)
+        {
+            if (string.Equals(args[i], argumentName, StringComparison.InvariantCultureIgnoreCase))
+            {
+                return args[i + 1];
+            }
+        }
+        return "";
+    }
+
+    public string[] GetCommandLineArguments()
+    {
+        if (Application.isEditor)
+        {
+            return simulatedCommandLineArguments.ToArray();
+        }
+        else
+        {
+#if UNITY_STANDALONE
+            return System.Environment.GetCommandLineArgs();
+#else
+            return Array.Empty<string>();
+#endif
         }
     }
 }

--- a/UltraStar Play/Assets/Common/Model/SettingsManager.cs
+++ b/UltraStar Play/Assets/Common/Model/SettingsManager.cs
@@ -106,6 +106,8 @@ public class SettingsManager : MonoBehaviour
         if (settingsPath.IsNullOrEmpty())
         {
             string commandLineSettingsPath = ApplicationManager.Instance.GetCommandLineArgument("--settingsPath");
+            commandLineSettingsPath = commandLineSettingsPath.Strip("\"", "\"");
+            commandLineSettingsPath = commandLineSettingsPath.Strip("'", "'");
             if (!commandLineSettingsPath.IsNullOrEmpty())
             {
                 settingsPath = commandLineSettingsPath;

--- a/UltraStar Play/Assets/Common/Model/SettingsManager.cs
+++ b/UltraStar Play/Assets/Common/Model/SettingsManager.cs
@@ -88,7 +88,7 @@ public class SettingsManager : MonoBehaviour
         if (!settingsOverwriteJson.IsNullOrEmpty())
         {
             settingsOverwriteJson = settingsOverwriteJson.Strip("\"", "\"");
-            settingsOverwriteJson = settingsOverwriteJson.Strip("\'", "\'");
+            settingsOverwriteJson = settingsOverwriteJson.Strip("'", "'");
             try
             {
                 JsonConverter.FillFromJson(settingsOverwriteJson, settings);

--- a/UltraStar Play/Assets/Common/Model/SettingsManager.cs
+++ b/UltraStar Play/Assets/Common/Model/SettingsManager.cs
@@ -84,7 +84,7 @@ public class SettingsManager : MonoBehaviour
 
     private void OverwriteSettingsWithCommandLineArguments()
     {
-        string settingsOverwriteJson = ApplicationManager.Instance.GetCommandLineArgument("-settingsOverwriteJson");
+        string settingsOverwriteJson = ApplicationManager.Instance.GetCommandLineArgument("--settingsOverwriteJson");
         if (!settingsOverwriteJson.IsNullOrEmpty())
         {
             settingsOverwriteJson = settingsOverwriteJson.Strip("\"", "\"");
@@ -105,7 +105,7 @@ public class SettingsManager : MonoBehaviour
     {
         if (settingsPath.IsNullOrEmpty())
         {
-            string commandLineSettingsPath = ApplicationManager.Instance.GetCommandLineArgument("-settingsPath");
+            string commandLineSettingsPath = ApplicationManager.Instance.GetCommandLineArgument("--settingsPath");
             if (!commandLineSettingsPath.IsNullOrEmpty())
             {
                 settingsPath = commandLineSettingsPath;

--- a/UltraStar Play/Assets/Common/Util/Extensions/StringExtensions.cs
+++ b/UltraStar Play/Assets/Common/Util/Extensions/StringExtensions.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using UnityEngine;
 
 public static class StringExtensions
@@ -21,5 +21,17 @@ public static class StringExtensions
     public static bool IsNullOrEmpty(this string txt)
     {
         return string.IsNullOrEmpty(txt);
+    }
+
+    // Removes opening and ending part from a string.
+    public static string Strip(this string txt, string opening, string ending)
+    {
+        if (txt.Length >= (opening.Length + ending.Length)
+            && txt.StartsWith(opening)
+            && txt.EndsWith(ending))
+        {
+            return txt.Substring(opening.Length, txt.Length - (opening.Length + ending.Length));
+        }
+        return txt;
     }
 }

--- a/UltraStar Play/Assets/Common/Util/Extensions/StringExtensions.cs
+++ b/UltraStar Play/Assets/Common/Util/Extensions/StringExtensions.cs
@@ -26,6 +26,11 @@ public static class StringExtensions
     // Removes opening and ending part from a string.
     public static string Strip(this string txt, string opening, string ending)
     {
+        if (txt == null)
+        {
+            return null;
+        }
+
         if (txt.Length >= (opening.Length + ending.Length)
             && txt.StartsWith(opening)
             && txt.EndsWith(ending))

--- a/UltraStar Play/Assets/Common/Util/JsonConverter.cs
+++ b/UltraStar Play/Assets/Common/Util/JsonConverter.cs
@@ -41,6 +41,12 @@ public static class JsonConverter
         return deserialized;
     }
 
+    public static void FillFromJson<T>(string json, T existingInstance)
+    {
+        fsData data = fsJsonParser.Parse(json);
+        serializer.TryDeserialize<T>(data, ref existingInstance).AssertSuccessWithoutWarnings();
+    }
+
     // https://stackoverflow.com/questions/4580397/json-formatter-in-c
     private static string FormatJson(string json)
     {

--- a/UltraStar Play/Assets/Scenes/SongSelect/SongSelectScene.unity
+++ b/UltraStar Play/Assets/Scenes/SongSelect/SongSelectScene.unity
@@ -4623,7 +4623,7 @@ PrefabInstance:
     - target: {fileID: 6645482432261325311, guid: 526f667f64d4f6949a1aa2bbba7ef376,
         type: 3}
       propertyPath: m_RootOrder
-      value: 15
+      value: 14
       objectReference: {fileID: 0}
     - target: {fileID: 1726528158099047256, guid: 526f667f64d4f6949a1aa2bbba7ef376,
         type: 3}
@@ -4644,6 +4644,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_RootOrder
       value: 18
+      objectReference: {fileID: 0}
+    - target: {fileID: 5594954776714672956, guid: 526f667f64d4f6949a1aa2bbba7ef376,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 15
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 526f667f64d4f6949a1aa2bbba7ef376, type: 3}


### PR DESCRIPTION
### What does this PR do?

As discussed in gitter
- You can pass --settingsPath to point to another settings location.
- Furthermore, you can specify --settingsOverwriteJson, which will overwrite anything that has been loaded from the normal Settings.json. Example: --settingsOverwriteJson {"GraphicSettings":{"useImageAsCursor":false}}.
- comparison of command line arguments is case-insensitive, such that --settingsOverwriteJson, --settingsOverwriteJSON or --SettingsOverWriteJSon would all work
- The ApplicationManager has a new list of strings, which is used in the Unity Editor to simulate command line arguments.

### Motivation

Was requested on Gitter. I already use it to point my "production" USPlay to my full song library instead of the few songs that I use for development.
