### PR TITLE
CamdAudioSamplesAnalyzer: do not return history pitch if detection failed

### DIFF
--- a/UltraStar Play/Assets/Common/Audio/Recording/CamdAudioSamplesAnalyzer.cs
+++ b/UltraStar Play/Assets/Common/Audio/Recording/CamdAudioSamplesAnalyzer.cs
@@ -82,17 +82,9 @@ public class CamdAudioSamplesAnalyzer : AbstractAudioSamplesAnalyzer
         int midiNote = bestCandidate.halftone + MinNote;
         if (midiNote < MidiUtils.SingableNoteMin || midiNote > MidiUtils.SingableNoteMax)
         {
-            // This pitch is impossible to sing. Thus, assuming the pitch detection failed.
-            // Use the newest pitch from the history instead if possible.
-            if (candidateHistory.IsEmpty)
-            {
-                return new PitchEvent(midiNote);
-            }
-            else
-            {
-                int historyMidiNote = candidateHistory.Front().halftone + MinNote;
-                return new PitchEvent(historyMidiNote);
-            }
+            // This pitch is impossible to sing.
+            // Thus, assume the pitch detection failed and do not add the pitch to the history.
+            return new PitchEvent(midiNote);
         }
         else
         {


### PR DESCRIPTION
This is a tiny change.

Do not return history pitch if detection failed because the PlayerNoteRecorder will round to the target note when an unsingable note has been detected (#154), which is better for the player

I once added the "return history pitch" thing to have a more stable recording in the song editor. However, for the game it feels sluggish and is unfair when the pitch detection is not responding to player input