### PR TITLE
Anst/better media format errors

### DIFF
--- a/UltraStar Play/Assets/Common/Audio/SongAudioPlayer/SongAudioPlayer.cs
+++ b/UltraStar Play/Assets/Common/Audio/SongAudioPlayer/SongAudioPlayer.cs
@@ -227,6 +227,7 @@ public class SongAudioPlayer : MonoBehaviour
         }
         else
         {
+            audioPlayer.clip = null;
             DurationOfSongInMillis = 0;
         }
     }
@@ -242,7 +243,7 @@ public class SongAudioPlayer : MonoBehaviour
 
     public void PlayAudio()
     {
-        if (!audioPlayer.isPlaying)
+        if (HasAudioClip && !audioPlayer.isPlaying)
         {
             audioPlayer.Play();
             playbackStartedEventStream.OnNext(PositionInSongInMillis);

--- a/UltraStar Play/Assets/Common/Video/SongVideoPlayer/SongVideoPlayer.cs
+++ b/UltraStar Play/Assets/Common/Video/SongVideoPlayer/SongVideoPlayer.cs
@@ -31,17 +31,38 @@ public class SongVideoPlayer : MonoBehaviour
 
     private float nextSyncTimeInSeconds;
 
+    private IDisposable jumpBackInSongEventStreamDisposable;
+    private IDisposable jumpForwardInSongEventStreamDisposable;
+
     public void Init(SongMeta songMeta, SongAudioPlayer songAudioPlayer)
     {
         this.SongMeta = songMeta;
         this.SongAudioPlayer = songAudioPlayer;
-        songAudioPlayer.JumpBackInSongEventStream.Subscribe(_ => SyncVideoWithMusic(true));
+        HasLoadedBackgroundImage = false;
+        InitEventSubscriber();
+        InitVideo(songMeta);
+    }
+
+    private void InitEventSubscriber()
+    {
+        // Jump backward in song
+        if (jumpBackInSongEventStreamDisposable != null)
+        {
+            jumpBackInSongEventStreamDisposable.Dispose();
+        }
+        jumpBackInSongEventStreamDisposable = SongAudioPlayer.JumpBackInSongEventStream
+            .Subscribe(_ => SyncVideoWithMusic(true));
+
+        // Jump forward in song
+        if (jumpForwardInSongEventStreamDisposable != null)
+        {
+            jumpForwardInSongEventStreamDisposable.Dispose();
+        }
         if (forceSyncOnForwardJumpInTheSong)
         {
-            songAudioPlayer.JumpForwardInSongEventStream.Subscribe(_ => SyncVideoWithMusic(true));
+            jumpForwardInSongEventStreamDisposable = SongAudioPlayer.JumpForwardInSongEventStream
+                .Subscribe(_ => SyncVideoWithMusic(true));
         }
-        HasLoadedBackgroundImage = false;
-        InitVideo(songMeta);
     }
 
     void Update()

--- a/UltraStar Play/Assets/Scenes/SongSelect/Preview/SongPreviewController.cs
+++ b/UltraStar Play/Assets/Scenes/SongSelect/Preview/SongPreviewController.cs
@@ -64,13 +64,20 @@ public class SongPreviewController : MonoBehaviour, INeedInjection
 
             // The video has an additional delay to load.
             // As long as no frame is ready yet, the VideoPlayer.time is 0.
-            if (songVideoPlayer.videoPlayer.time <= 0)
+            if (songVideoPlayer.HasLoadedVideo && songVideoPlayer.videoPlayer.time <= 0)
             {
                 videoFadeInStartInSeconds = Time.time;
             }
             float videoPercent = (Time.time - videoFadeInStartInSeconds) / videoFadeInDurationInSeconds;
             videoPercent = NumberUtils.Limit(videoPercent, 0, 1);
-            songVideoPlayer.videoImage.SetAlpha(videoPercent);
+            if (songVideoPlayer.HasLoadedVideo)
+            {
+                songVideoPlayer.videoImage.SetAlpha(videoPercent);
+            }
+            else if (songVideoPlayer.HasLoadedBackgroundImage)
+            {
+                songVideoPlayer.backgroundImage.SetAlpha(videoPercent);
+            }
 
             if (audioPercent >= 1 && videoPercent >= 1)
             {
@@ -139,7 +146,7 @@ public class SongPreviewController : MonoBehaviour, INeedInjection
         StopAllCoroutines();
         songAudioPlayer.PauseAudio();
         isFadeInStarted = false;
-        songVideoPlayer.videoImageAndPlayerContainer.gameObject.SetActive(false);
+        songVideoPlayer.gameObject.SetActive(false);
     }
 
     private void StartSongPreview(SongMeta songMeta, int previewStartInMillis)
@@ -164,9 +171,11 @@ public class SongPreviewController : MonoBehaviour, INeedInjection
             return;
         }
 
-        songVideoPlayer.videoImageAndPlayerContainer.gameObject.SetActive(true);
+        songVideoPlayer.gameObject.SetActive(true);
         songVideoPlayer.Init(songMeta, songAudioPlayer);
         songVideoPlayer.videoImage.SetAlpha(0);
+        songVideoPlayer.backgroundImage.SetAlpha(0);
+        songVideoPlayer.StartVideoOrShowBackgroundImage();
     }
 
     private void StartAudioPreview(SongMeta songMeta, int previewStartInMillis)

--- a/UltraStar Play/Assets/Scenes/SongSelect/Preview/SongPreviewController.cs
+++ b/UltraStar Play/Assets/Scenes/SongSelect/Preview/SongPreviewController.cs
@@ -22,6 +22,9 @@ public class SongPreviewController : MonoBehaviour, INeedInjection
     private bool isFadeInStarted;
 
     [Inject]
+    private UiManager uiManager;
+
+    [Inject]
     private SongRouletteController songRouletteController;
 
     [Inject]
@@ -183,6 +186,13 @@ public class SongPreviewController : MonoBehaviour, INeedInjection
         songAudioPlayer.Init(songMeta);
         songAudioPlayer.PositionInSongInMillis = previewStartInMillis;
         songAudioPlayer.audioPlayer.volume = 0;
-        songAudioPlayer.PlayAudio();
+        if (songAudioPlayer.HasAudioClip)
+        {
+            songAudioPlayer.PlayAudio();
+        }
+        else
+        {
+            uiManager.CreateNotification("Audio could not be loaded.", Colors.red);
+        }
     }
 }

--- a/UltraStar Play/Assets/Scenes/SongSelect/SongSelectSceneKeyboardInputController.cs
+++ b/UltraStar Play/Assets/Scenes/SongSelect/SongSelectSceneKeyboardInputController.cs
@@ -92,7 +92,7 @@ public class SongSelectSceneKeyboardInputController : MonoBehaviour, INeedInject
         // Open the sing scene via Return / Enter
         if (Input.GetKeyUp(KeyCode.Return) && IsNoControlOrSongButtonFocused())
         {
-            songSelectSceneController.StartSingScene();
+            songSelectSceneController.CheckAudioAndStartSingScene();
         }
 
         // Toggle active players with Tab


### PR DESCRIPTION
### What does this PR do?

- Do not preview video types that are not supported
    - as fallback, the background image for a song is shown (also with fade-in animation)
- Better error handling for unsupported audio formats
    - An error dialog is shown when attempting to start a song with unsupported audio file
- Some fixes / improvements when audio files / video files do not exist or have other issues

### Closes Issue(s)

#150, #149 
