### PR TITLE
mute / unmute audio via F12 (global keyboard shortcut)

### DIFF
--- a/UltraStar Play/Assets/Common/Audio/AudioManager.cs
+++ b/UltraStar Play/Assets/Common/Audio/AudioManager.cs
@@ -14,11 +14,29 @@ public class AudioManager : MonoBehaviour
     private static readonly int criticalCacheSize = 10;
     private static readonly Dictionary<string, CachedAudioClip> audioClipCache = new Dictionary<string, CachedAudioClip>();
 
+    private static float volumeBeforeMute = -1;
+
     public static AudioManager Instance
     {
         get
         {
             return GameObjectUtils.FindComponentWithTag<AudioManager>("AudioManager");
+        }
+    }
+
+    public static void ToggleMuteAudio()
+    {
+        if (volumeBeforeMute >= 0)
+        {
+            AudioListener.volume = volumeBeforeMute;
+            volumeBeforeMute = -1;
+            UiManager.Instance.CreateNotification("Unmute");
+        }
+        else
+        {
+            volumeBeforeMute = AudioListener.volume;
+            AudioListener.volume = 0;
+            UiManager.Instance.CreateNotification("Mute");
         }
     }
 

--- a/UltraStar Play/Assets/Common/Input/GlobalKeyboardShortcutManager.cs
+++ b/UltraStar Play/Assets/Common/Input/GlobalKeyboardShortcutManager.cs
@@ -20,5 +20,11 @@ public class GlobalKeyboardShortcutManager : MonoBehaviour
             StartCoroutine(CoroutineUtils.ExecuteAfterDelayInSeconds(0.1f,
                 () => SettingsManager.Instance.Settings.GraphicSettings.fullScreenMode = Screen.fullScreenMode));
         }
+
+        // Mute / unmute audio via F12
+        if (Input.GetKeyUp(KeyCode.F12))
+        {
+            AudioManager.ToggleMuteAudio();
+        }
     }
 }


### PR DESCRIPTION
### What does this PR do?

- add shortcut to mute / unmute audio via F12 (global keyboard shortcut)
    - the mute state is not persisted in the settings. It is intended to temporarily stop audio output.
