### PR TITLE
FolderScanner: do not scan hidden folders (starting with dot)

### DIFF
--- a/UltraStar Play/Assets/Common/Util/File/FolderScanner.cs
+++ b/UltraStar Play/Assets/Common/Util/File/FolderScanner.cs
@@ -9,10 +9,12 @@ using UnityEngine;
 public class FolderScanner
 {
     private readonly string fileExtensionPattern;
+    private readonly bool includeHiddenFolders;
 
-    public FolderScanner(string fileExtensionPattern)
+    public FolderScanner(string fileExtensionPattern, bool includeHiddenFolders = false)
     {
         this.fileExtensionPattern = fileExtensionPattern;
+        this.includeHiddenFolders = includeHiddenFolders;
 
         // Checks
         if (this.fileExtensionPattern == null || this.fileExtensionPattern.Trim().Length < 3)
@@ -28,6 +30,11 @@ public class FolderScanner
 
     public List<string> GetFiles(string folder, bool recursive)
     {
+        if (!includeHiddenFolders && IsHiddenFolder(folder))
+        {
+            return new List<string>();
+        }
+
         List<string> result = new List<string>();
         DirectoryInfo dirInfo = new DirectoryInfo(folder);
         if (folder == null || !System.IO.Directory.Exists(folder))
@@ -60,6 +67,14 @@ public class FolderScanner
         }
 
         return result;
+    }
+
+    private static bool IsHiddenFolder(string folder)
+    {
+        // By convention, a hidden folder starts with a dot
+        // (at least on Unix based operating systems such as Linux, MacOS, Android)
+        string folderName = Path.GetFileName(folder);
+        return folderName.StartsWith(".");
     }
 
 }

--- a/UltraStar Play/Assets/Scenes/SongSelect/SongSelectSceneController.cs
+++ b/UltraStar Play/Assets/Scenes/SongSelect/SongSelectSceneController.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using UnityEngine;
-using System;
 using UnityEngine.UI;
 using System.Linq;
 using UniRx;
@@ -325,6 +324,8 @@ public class SongSelectSceneController : MonoBehaviour, IOnHotSwapFinishedListen
     {
         searchTextInputField.Text = "";
         searchTextInputField.Hide();
+        // Remove the focus from the search input text field
+        EventSystem.current.SetSelectedGameObject(null);
     }
 
     public string GetSearchText()

--- a/UltraStar Play/Assets/Scenes/SongSelect/SongSelectSceneKeyboardInputController.cs
+++ b/UltraStar Play/Assets/Scenes/SongSelect/SongSelectSceneKeyboardInputController.cs
@@ -76,6 +76,7 @@ public class SongSelectSceneKeyboardInputController : MonoBehaviour, INeedInject
                 || (Input.GetKeyUp(KeyCode.Return) && songSelectSceneController.IsSearchTextInputHasFocus()))
             {
                 songSelectSceneController.DisableSearch();
+                return;
             }
         }
         else


### PR DESCRIPTION
### What does this PR do?

See title.

I also changed two lines to fix the issue reported on Gitter: search input field was still focused after it has been disabled.

### Closes Issue(s)

see #149 