### PR TITLE
Anst/no domain reload

### DIFF
--- a/UltraStar Play/Assets/Common/Audio/AudioManager.cs
+++ b/UltraStar Play/Assets/Common/Audio/AudioManager.cs
@@ -11,6 +11,17 @@ using UnityEngine.Networking;
 // Use this over AudioUtils because AudioUtils does not cache AudioClips.
 public class AudioManager : MonoBehaviour
 {
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+    static void Init()
+    {
+        volumeBeforeMute = -1;
+        foreach (CachedAudioClip cachedAudioClip in new List<CachedAudioClip>(audioClipCache.Values))
+        {
+            RemoveCachedAudioClip(cachedAudioClip);
+        }
+        audioClipCache.Clear();
+    }
+
     private static readonly int criticalCacheSize = 10;
     private static readonly Dictionary<string, CachedAudioClip> audioClipCache = new Dictionary<string, CachedAudioClip>();
 
@@ -102,9 +113,22 @@ public class AudioManager : MonoBehaviour
 
         if (oldest != null)
         {
-            oldest.StreamedAudioClip?.UnloadAudioData();
-            oldest.FullAudioClip?.UnloadAudioData();
-            audioClipCache.Remove(oldest.Path);
+            RemoveCachedAudioClip(oldest);
+        }
+    }
+
+    private static void RemoveCachedAudioClip(CachedAudioClip cachedAudioClip)
+    {
+        audioClipCache.Remove(cachedAudioClip.Path);
+
+        if (cachedAudioClip.StreamedAudioClip != null)
+        {
+            cachedAudioClip.StreamedAudioClip.UnloadAudioData();
+        }
+
+        if (cachedAudioClip.FullAudioClip != null)
+        {
+            cachedAudioClip.FullAudioClip.UnloadAudioData();
         }
     }
 

--- a/UltraStar Play/Assets/Common/Graphics/ImageManager.cs
+++ b/UltraStar Play/Assets/Common/Graphics/ImageManager.cs
@@ -6,6 +6,16 @@ using UnityEngine.UI;
 // Handles loading and caching of images.
 public class ImageManager
 {
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+    static void Init()
+    {
+        foreach (CachedSprite cachedSprite in new List<CachedSprite>(spriteCache.Values))
+        {
+            RemoveCachedSprite(cachedSprite);
+        }
+        spriteCache.Clear();
+    }
+
     // When the cache has reached the critical size, then unused sprites are searched in the scene
     // and removed from memory.
     private static readonly int criticalCacheSize = 50;
@@ -88,8 +98,14 @@ public class ImageManager
     {
         spriteCache.Remove(cachedSprite.Path);
         // Destoying the texture is important to free the memory.
-        GameObject.Destroy(cachedSprite.Sprite.texture);
-        GameObject.Destroy(cachedSprite.Sprite);
+        if (cachedSprite.Sprite != null)
+        {
+            if (cachedSprite.Sprite.texture != null)
+            {
+                GameObject.Destroy(cachedSprite.Sprite.texture);
+            }
+            GameObject.Destroy(cachedSprite.Sprite);
+        }
     }
 
     private class CachedSprite

--- a/UltraStar Play/Assets/Common/Model/SettingsManager.cs
+++ b/UltraStar Play/Assets/Common/Model/SettingsManager.cs
@@ -8,6 +8,14 @@ using UnityEngine;
 
 public class SettingsManager : MonoBehaviour
 {
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+    static void Init()
+    {
+        settingsPath = null;
+        settings = null;
+        initializedResolution = false;
+    }
+
     public static SettingsManager Instance
     {
         get

--- a/UltraStar Play/Assets/Common/Model/SongMetaManager.cs
+++ b/UltraStar Play/Assets/Common/Model/SongMetaManager.cs
@@ -13,9 +13,17 @@ public class SongMetaManager : MonoBehaviour
 {
     private static readonly object scanLock = new object();
 
-    public int SongsFound { get; private set; }
-    public int SongsSuccess { get; private set; }
-    public int SongsFailed { get; private set; }
+    // The collection of songs is static to be persisted across scenes.
+    // The collection is filled with song datas from a background thread, thus a thread-safe collection is used.
+    private static ConcurrentBag<SongMeta> songMetas = new ConcurrentBag<SongMeta>();
+
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+    static void Init()
+    {
+        songMetas = new ConcurrentBag<SongMeta>();
+        isSongScanStarted = false;
+        isSongScanFinished = false;
+    }
 
     public static SongMetaManager Instance
     {
@@ -24,10 +32,6 @@ public class SongMetaManager : MonoBehaviour
             return GameObjectUtils.FindComponentWithTag<SongMetaManager>("SongMetaManager");
         }
     }
-
-    // The collection of songs is static to be persisted across scenes.
-    // The collection is filled with song datas from a background thread, thus a thread-safe collection is used.
-    private static readonly ConcurrentBag<SongMeta> songMetas = new ConcurrentBag<SongMeta>();
 
     private static bool isSongScanStarted;
     private static bool isSongScanFinished;
@@ -41,6 +45,10 @@ public class SongMetaManager : MonoBehaviour
 
     private readonly Subject<SongScanFinishedEvent> songScanFinishedEventStream = new Subject<SongScanFinishedEvent>();
     public IObservable<SongScanFinishedEvent> SongScanFinishedEventStream => songScanFinishedEventStream;
+
+    public int SongsFound { get; private set; }
+    public int SongsSuccess { get; private set; }
+    public int SongsFailed { get; private set; }
 
     public void Add(SongMeta songMeta)
     {

--- a/UltraStar Play/Assets/Common/Model/StatsManager.cs
+++ b/UltraStar Play/Assets/Common/Model/StatsManager.cs
@@ -8,6 +8,12 @@ using UnityEngine;
 [Serializable]
 public class StatsManager : MonoBehaviour
 {
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+    static void Init()
+    {
+        statistics = null;
+    }
+
     // Statistics are static to persist across scenes
     private static Statistics statistics;
     public Statistics Statistics

--- a/UltraStar Play/Assets/Common/Playlist/PlaylistManager.cs
+++ b/UltraStar Play/Assets/Common/Playlist/PlaylistManager.cs
@@ -8,6 +8,14 @@ using System.IO;
 
 public class PlaylistManager : MonoBehaviour
 {
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+    static void Init()
+    {
+        playlistToFilePathMap.Clear();
+        playlists.Clear();
+        favoritesPlaylist = new UltraStarPlaylist();
+    }
+
     public static PlaylistManager Instance
     {
         get

--- a/UltraStar Play/Assets/Common/Scene/SceneNavigator.cs
+++ b/UltraStar Play/Assets/Common/Scene/SceneNavigator.cs
@@ -6,6 +6,12 @@ using UnityEngine.SceneManagement;
 
 public class SceneNavigator : MonoBehaviour
 {
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+    static void Init()
+    {
+        staticSceneDatas.Clear();
+    }
+
     public static SceneNavigator Instance
     {
         get

--- a/UltraStar Play/Assets/Common/Theme/ThemeManager.cs
+++ b/UltraStar Play/Assets/Common/Theme/ThemeManager.cs
@@ -8,10 +8,16 @@ using UnityEngine;
 [ExecuteInEditMode]
 public class ThemeManager : MonoBehaviour
 {
-    public string currentThemeName;
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+    static void Init()
+    {
+        themes.Clear();
+    }
 
     // Themes is static to be persisted across scenes.
     private static readonly List<Theme> themes = new List<Theme>();
+
+    public string currentThemeName;
 
     public static ThemeManager Instance
     {

--- a/UltraStar Play/Assets/Common/UI/UiManager.cs
+++ b/UltraStar Play/Assets/Common/UI/UiManager.cs
@@ -9,6 +9,12 @@ using UniInject;
 
 public class UiManager : MonoBehaviour, INeedInjection
 {
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+    static void Init()
+    {
+        LeanTween.ResetStaticFields();
+    }
+
     public static UiManager Instance
     {
         get

--- a/UltraStar Play/Assets/Common/UI/UiManager.cs
+++ b/UltraStar Play/Assets/Common/UI/UiManager.cs
@@ -9,12 +9,6 @@ using UniInject;
 
 public class UiManager : MonoBehaviour, INeedInjection
 {
-    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
-    static void Init()
-    {
-        LeanTween.ResetStaticFields();
-    }
-
     public static UiManager Instance
     {
         get

--- a/UltraStar Play/Assets/Scenes/SongEditor/History/SongEditorHistoryManager.cs
+++ b/UltraStar Play/Assets/Scenes/SongEditor/History/SongEditorHistoryManager.cs
@@ -12,6 +12,12 @@ using UniRx;
 
 public class SongEditorHistoryManager : MonoBehaviour, INeedInjection, ISceneInjectionFinishedListener
 {
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+    static void Init()
+    {
+        songMetaToSongEditorMementoMap.Clear();
+    }
+
     private static readonly int maxHistoryLength = 20;
 
     // Static reference to last state to load it when opening the song editor scene

--- a/UltraStar Play/ProjectSettings/EditorSettings.asset
+++ b/UltraStar Play/ProjectSettings/EditorSettings.asset
@@ -22,7 +22,7 @@ EditorSettings:
   m_AsyncShaderCompilation: 1
   m_CachingShaderPreprocessor: 0
   m_EnterPlayModeOptionsEnabled: 1
-  m_EnterPlayModeOptions: 0
+  m_EnterPlayModeOptions: 1
   m_GameObjectNamingDigits: 1
   m_GameObjectNamingScheme: 2
   m_AssetNamingUsesSpace: 1

--- a/tools/download-dependencies/download-csharpsynthforunity.sh
+++ b/tools/download-dependencies/download-csharpsynthforunity.sh
@@ -10,7 +10,7 @@ cd CSharpSynthForUnity
 
 echo "Cloning CSharpSynthForUnity from remote..."
 git init
-git remote add origin https://github.com/achimmihca/CSharpSynthForUnity.git
+git remote add origin https://github.com/UltraStar-Deluxe/CSharpSynthForUnity.git
 git config core.sparsecheckout true
 echo "Assets/*" >> .git/info/sparse-checkout
 # UltraStar-Play-subset is a dedicated branch for the UltraStar Play project

--- a/tools/download-dependencies/download-leantween.sh
+++ b/tools/download-dependencies/download-leantween.sh
@@ -10,7 +10,7 @@ cd LeanTween
 
 echo "Cloning LeanTween from remote..."
 git init
-git remote add origin https://github.com/achimmihca/LeanTween.git
+git remote add origin https://github.com/UltraStar-Deluxe/LeanTween.git
 git config core.sparsecheckout true
 echo "Assets/LeanTween/Framework/*" >> .git/info/sparse-checkout
 echo "Assets/LeanTween/Editor/*" >> .git/info/sparse-checkout

--- a/tools/download-dependencies/download-leantween.sh
+++ b/tools/download-dependencies/download-leantween.sh
@@ -10,16 +10,16 @@ cd LeanTween
 
 echo "Cloning LeanTween from remote..."
 git init
-git remote add origin https://github.com/dentedpixel/LeanTween.git
+git remote add origin https://github.com/achimmihca/LeanTween.git
 git config core.sparsecheckout true
 echo "Assets/LeanTween/Framework/*" >> .git/info/sparse-checkout
 echo "Assets/LeanTween/Editor/*" >> .git/info/sparse-checkout
 echo "Assets/LeanTween/Documentation/*" >> .git/info/sparse-checkout
 echo "Assets/LeanTween/License.txt" >> .git/info/sparse-checkout
 echo "Assets/LeanTween/ReadMe.txt" >> .git/info/sparse-checkout
-# commit of 10th November 2018: f387a18039f1eae62ab3e0a706c3e1002a4dcb22
+# commit of 18th September 2020: ea745c3f94d8682327c912030dfc6b65cbe1ced5
 git pull --depth=100 origin master
-git checkout f387a18039f1eae62ab3e0a706c3e1002a4dcb22
+git checkout ea745c3f94d8682327c912030dfc6b65cbe1ced5
 
 echo "Moving downloaded files to correct position for this project..."
 mv -v ./Assets/LeanTween/* ./


### PR DESCRIPTION
### What does this PR do?

As mentioned in the last PR, a new Unity feature allows to disable [Domain Reload](https://docs.unity3d.com/2020.1/Documentation/Manual/DomainReloading.html). This makes start / stop Play Mode 10x faster.
For this to work, static fields have to be reset explicitly.

This PR adds the needed annotations and reset of static fields.
The PR also changes the downloaded dependency of LeanTween to a custom fork, where the static fields are reset.
The other plugins seem to work as is.

### Motivation

Make Unity development fun again :)
Starting / stopping a scene now takes 2-3 seconds instead of 20-30.