### PR TITLE
fixed microphone issue under linux

### DIFF
--- a/UltraStar Play/Assets/Common/Audio/Recording/MicSampleRecorder.cs
+++ b/UltraStar Play/Assets/Common/Audio/Recording/MicSampleRecorder.cs
@@ -30,6 +30,12 @@ public class MicSampleRecorder : MonoBehaviour
             {
                 Microphone.GetDeviceCaps(micProfile.Name, out int minFrequency, out int maxFrequency);
                 SampleRateHz = maxFrequency;
+                // a value of zero indicates, that the device supports any frequency
+                // https://docs.unity3d.com/ScriptReference/Microphone.GetDeviceCaps.html
+                if (SampleRateHz == 0)
+                {
+                    SampleRateHz = DefaultSampleRateHz;
+                }
                 MicSamples = new float[SampleRateHz];
                 if (restartPitchDetection)
                 {


### PR DESCRIPTION
###  What does this PR do?

On Linux (Debian Bullseye) an exception was thrown in the Recording setting:
"ArgumentException: Frequency of recording must be greater than zero (was: 0 Hz)".
This exception prevented the usage of any microphone in Ultrastar Play.
The issue was caused by misinterpreting the return value "maxFrequency" of the Unity function "GetDeviceCaps".
A value of zero indicates, that the device can handle any frequency. 
By passing this value directly to "UnityEngine.Microphone.Start()", the exception is generated.
Therefore a case distinction has to be made beforehand.
