### PR TITLE
added travis config to build iOS and Android

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,3 +71,19 @@ jobs:
         s3_region: "eu-west-1"
         paths:
         - "$(pwd)/UltraStarPlay-build.tar.gz"
+  - stage: build
+    env: BUILD_TARGET=Android IMAGE_NAME=gableroux/unity3d:2020.1.5f1-android
+    script: "./tools/travis/docker_build.sh"
+    addons:
+      artifacts:
+        s3_region: "eu-west-1"
+        paths:
+        - "$(pwd)/UltraStarPlay-build.tar.gz"
+  - stage: build
+    env: BUILD_TARGET=iOS IMAGE_NAME=gableroux/unity3d:2020.1.5f1-ios
+    script: "./tools/travis/docker_build.sh"
+    addons:
+      artifacts:
+        s3_region: "eu-west-1"
+        paths:
+        - "$(pwd)/UltraStarPlay-build.tar.gz"


### PR DESCRIPTION
### What does this PR do?

Attempt to also build iOS and Android on Travis.

I found the docker images at https://hub.docker.com/r/gableroux/unity3d/tags

and the BuildTarget "iOS" and "Android" on https://docs.unity3d.com/ScriptReference/BuildTarget.html

So maybe this will just work.

### Closes Issue(s)

close #189 

### More

- documentation about CI has been updated
