### PR TITLE
traivs: removed android build because it was not finding NDK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,14 +72,6 @@ jobs:
         paths:
         - "$(pwd)/UltraStarPlay-build.tar.gz"
   - stage: build
-    env: BUILD_TARGET=Android IMAGE_NAME=gableroux/unity3d:2020.1.5f1-android
-    script: "./tools/travis/docker_build.sh"
-    addons:
-      artifacts:
-        s3_region: "eu-west-1"
-        paths:
-        - "$(pwd)/UltraStarPlay-build.tar.gz"
-  - stage: build
     env: BUILD_TARGET=iOS IMAGE_NAME=gableroux/unity3d:2020.1.5f1-ios
     script: "./tools/travis/docker_build.sh"
     addons:


### PR DESCRIPTION
### What does this PR do?

Remove Android build from travis.

The build is green, but did not generate anything and was running forever.
The log says: 
```
Android NDK was not installed with Unity at /opt/Unity/Editor/Data/PlaybackEngines/AndroidPlayer/NDK
```

I think it might be this issue: https://gitlab.com/gableroux/unity3d/-/issues/85
At the end of the thread, it is said that newer docker images are available over here: https://hub.docker.com/r/unityci/editor/tags?page=1&name=2020.1.5
Maybe these do not have this issue.

However, it could be that these images require a new Unity license activation. And I am too lazy right now to repeat this procedure.

So conclusion: Android build failed. Remove it and see how iOS will do ;)
