### PR TITLE
travis: removed android build because it was failing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,14 +72,6 @@ jobs:
         paths:
         - "$(pwd)/UltraStarPlay-build.tar.gz"
   - stage: build
-    env: BUILD_TARGET=Android IMAGE_NAME=unityci/editor:ubuntu-2020.1.5f1-android-0.7.0
-    script: "./tools/travis/docker_build.sh"
-    addons:
-      artifacts:
-        s3_region: "eu-west-1"
-        paths:
-        - "$(pwd)/UltraStarPlay-build.tar.gz"
-  - stage: build
     env: BUILD_TARGET=iOS IMAGE_NAME=gableroux/unity3d:2020.1.5f1-ios
     script: "./tools/travis/docker_build.sh"
     addons:


### PR DESCRIPTION
### What does this PR do?

Remove the Android build again from TravisCI.

The build failed because the Unity editor was not found. Thus, the other docker image has bigger differences than I had expected.
One would have to fiddle around first with the new docker image to get this working and then migrate all build to them.
