### PR TITLE
fix NewVersionChecker

### DIFF
--- a/UltraStar Play/Assets/Editor/Tests/CompareVersionStringTest.cs
+++ b/UltraStar Play/Assets/Editor/Tests/CompareVersionStringTest.cs
@@ -1,0 +1,41 @@
+﻿using System.Collections.Generic;
+using NUnit.Framework;
+
+public class CompareVersionStringTest
+{
+    [Test]
+    public void CompareVersionStringTestMethod()
+    {
+        Dictionary<string, string> smallVersionToBigVersion = new Dictionary<string, string>
+        {
+            {"5", "20"},
+            {"1.1.1", "1.1.2"},
+            {"1.2.1", "1.2.2"},
+            {"1.1.2", "1.2.0"},
+            {"1.2.0", "1.2.0.5"},
+            {"2020.1.5f", "2020.1.6f"},
+            {"2020.1.4f", "2020.1.6f"},
+            {"2020.04", "2020.9"},
+            {"2020.9", "2020.11"},
+            {"2020.1", "2020.1-devbuild1"},
+            {"2020.1-devbuild1", "2020.1-devbuild2"},
+        };
+
+        foreach (KeyValuePair<string, string> smallVersionAndBigVersion in smallVersionToBigVersion)
+        {
+            string smallVersion = smallVersionAndBigVersion.Key;
+            string bigVersion = smallVersionAndBigVersion.Value;
+
+            DoTest(-1, smallVersion, bigVersion);
+            DoTest(1, bigVersion, smallVersion);
+            DoTest(0, smallVersion, smallVersion);
+            DoTest(0, bigVersion, bigVersion);
+        }
+    }
+
+    private void DoTest(int expectedResult, string versionA, string versionB)
+    {
+        int actualResult = NewVersionChecker.CompareVersionString(versionA, versionB);
+        Assert.AreEqual(expectedResult, actualResult, $"Compare('{versionA}', '{versionB}') returned {actualResult} but expected {expectedResult}");
+    }
+}

--- a/UltraStar Play/Assets/Editor/Tests/CompareVersionStringTest.cs.meta
+++ b/UltraStar Play/Assets/Editor/Tests/CompareVersionStringTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 327778731a46fd2448ed9d9858c00336
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UltraStar Play/Assets/Editor/Tests/USPlayEditorTests.asmdef
+++ b/UltraStar Play/Assets/Editor/Tests/USPlayEditorTests.asmdef
@@ -1,12 +1,14 @@
 {
-    "name": "USPlayEditor",
+    "name": "USPlayEditorTests",
     "references": [
         "Plugins",
         "UniRx",
         "UniInject",
-        "Common"
+        "Common",
+        "Scenes"
     ],
     "optionalUnityReferences": [
+        "TestAssemblies"
     ],
     "includePlatforms": [
         "Editor"

--- a/UltraStar Play/Assets/Editor/Tests/USPlayEditorTests.asmdef.meta
+++ b/UltraStar Play/Assets/Editor/Tests/USPlayEditorTests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4397c2eff7c2ae740b5d9cc43d5f4246
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UltraStar Play/Assets/Scenes/Main/CompareVersionException.cs
+++ b/UltraStar Play/Assets/Scenes/Main/CompareVersionException.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+public class CompareVersionException : Exception
+{
+    public CompareVersionException(string message) : base(message)
+    {
+    }
+}

--- a/UltraStar Play/Assets/Scenes/Main/CompareVersionException.cs.meta
+++ b/UltraStar Play/Assets/Scenes/Main/CompareVersionException.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 896d7454bce49a24daed113989b66791
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/documentation/assembly-dependencies.plantuml
+++ b/documentation/assembly-dependencies.plantuml
@@ -1,4 +1,4 @@
-@startuml
+@startuml "assembly-dependencies"
 
 ' ---------------------------
 ' Assets/Plugins
@@ -10,10 +10,10 @@ component [Plugins] {
     [NLayer]
     [SharpZipLib]
     [Threads]
+    [UniInject]
+    [UniRx]
+    [TextMesh Pro]
 }
-
-[UniInject]
-[UniRx]
 
 ' ---------------------------
 ' Assets/Common
@@ -28,6 +28,7 @@ component [Plugins] {
 ' ---------------------------
 ' Assets/Editor
 [USPlayEditor]
+[USPlayEditorTests]
 
 ' ---------------------------
 ' Unity environment
@@ -37,14 +38,15 @@ component [Plugins] {
 ' Dependencies
 
 Common --> Plugins
-Common --> UniRx
-Common --> UniInject
 
 Scenes --> Common
 SongEditorScene --> Common
 Demos --> Common
 
 USPlayEditor --> Common
-USPlayEditor --> NUnit
+
+USPlayEditorTests --> Common
+USPlayEditorTests --> Scenes
+USPlayEditorTests --> NUnit
 
 @enduml


### PR DESCRIPTION
### What does this PR do?

The NewVersionChecker was comparing the numbers of a version string by simply removing all non-digit text.
However, this is not good, because it will consider "1.1.1" smaller than "1.01.01" (because 111 < 10101).

So now
- compare each number separately
- added test for version comparison
- editor tests can now access scene classes via new asmdef file
    - removed test assembly from "normal" editor assembly
    - updated assembly-dependencies documentation file (plantuml)
