### PR TITLE
fix: PlayerPitchTracker in SingScene was using wrong sample rate

### DIFF
--- a/UltraStar Play/Assets/Common/Audio/Recording/MicSampleRecorder.cs
+++ b/UltraStar Play/Assets/Common/Audio/Recording/MicSampleRecorder.cs
@@ -45,8 +45,10 @@ public class MicSampleRecorder : MonoBehaviour
         }
     }
 
-    public float[] MicSamples { get; private set; } = new float[DefaultSampleRateHz];
-    public int SampleRateHz { get; private set; } = DefaultSampleRateHz;
+    // SampleRateHz is available after the MicProfile has been set.
+    public int SampleRateHz { get; private set; }
+    // The MicSamples array has the length of the SampleRateHz (one float value per sample.)
+    public float[] MicSamples { get; private set; }
 
     private Subject<RecordingEvent> recordingEventStream = new Subject<RecordingEvent>();
     public IObservable<RecordingEvent> RecordingEventStream
@@ -103,7 +105,7 @@ public class MicSampleRecorder : MonoBehaviour
             IsRecording = false;
             return;
         }
-        Debug.Log($"Starting recording with '{MicProfile.Name}'");
+        Debug.Log($"Starting recording with '{MicProfile.Name}' at {SampleRateHz} Hz");
 
         micAmplifyMultiplier = micProfile.AmplificationMultiplier();
 
@@ -119,6 +121,7 @@ public class MicSampleRecorder : MonoBehaviour
             if (stopwatch.ElapsedMilliseconds > 1000)
             {
                 IsRecording = false;
+                Debug.LogError("Microphone did not provide any samples. Took emergency exit out of busy waiting.");
                 return;
             }
         }

--- a/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerPitchTracker.cs
+++ b/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerPitchTracker.cs
@@ -87,10 +87,12 @@ public partial class PlayerPitchTracker : MonoBehaviour, INeedInjection
         if (micProfile != null)
         {
             roundingDistance = playerProfile.Difficulty.GetRoundingDistance();
-            audioSamplesAnalyzer = MicPitchTracker.CreateAudioSamplesAnalyzer(settings.AudioSettings.pitchDetectionAlgorithm, micSampleRecorder.SampleRateHz);
-            audioSamplesAnalyzer.Enable();
             micSampleRecorder.MicProfile = micProfile;
             micSampleRecorder.StartRecording();
+
+            // The AudioSampleAnalyzer uses the MicSampleRecorder's sampleRateHz. Thus, it must be initialized after the MicSampleRecorder.
+            audioSamplesAnalyzer = MicPitchTracker.CreateAudioSamplesAnalyzer(settings.AudioSettings.pitchDetectionAlgorithm, micSampleRecorder.SampleRateHz);
+            audioSamplesAnalyzer.Enable();
         }
         else
         {


### PR DESCRIPTION
### What does this PR do?

Fix PlayerPitchTracker sample rate.

This is a tiny but important PR.

- PlayerPitchTracker first created the analyzer and then initialized the MicSampleRecorder. This way, it was using the default sample rate instead of the correct sample rate for the mic
    - I removed the assigned default values. The fields should not be read before the MicProfile has been set.
        - Now, the PlayerPitchTracker would just record no notes instead of wrong notes.

- Only the SingScene was affected. Other scenes already initialized the analyzer correctly.

- I noticed that my notes were always just a bit off. Turned out that it was recorded with 48000 Hz but the PlayerPitchTracker used 44100 Hz.

If your mic uses a different sample rate than 44100 or 22050, then you will get much better note recording in the game now.
