### PR TITLE
SongSelect: indicate active filter via font-style of song-count-label (make it underlined)

### DIFF
--- a/UltraStar Play/Assets/Common/HsvColor/HsvColorMaterial.mat
+++ b/UltraStar Play/Assets/Common/HsvColor/HsvColorMaterial.mat
@@ -85,3 +85,4 @@ Material:
     - _Color: {r: 1, g: 1, b: 1, a: 1}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
     - _HSVAAdjust: {r: 0, g: 0, b: 0, a: 0}
+  m_BuildTextureStacks: []

--- a/UltraStar Play/Assets/Scenes/Scenes.asmdef
+++ b/UltraStar Play/Assets/Scenes/Scenes.asmdef
@@ -5,6 +5,7 @@
         "UniRx",
         "UniInject",
         "Common",
-        "UnityUIExtensions"
+        "UnityUIExtensions",
+        "Unity.TextMeshPro"
     ]
 }

--- a/UltraStar Play/Assets/Scenes/SongSelect/SongSelectScene.unity
+++ b/UltraStar Play/Assets/Scenes/SongSelect/SongSelectScene.unity
@@ -1143,12 +1143,12 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
-  - {fileID: 778661797}
+  - {fileID: 1346973258}
   m_Father: {fileID: 532231402}
   m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.7235639, y: 0.037300073}
-  m_AnchorMax: {x: 0.9496025, y: 0.16705212}
+  m_AnchorMin: {x: 0.6622311, y: 0.03730009}
+  m_AnchorMax: {x: 0.9769124, y: 0.16705212}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -1897,7 +1897,7 @@ MonoBehaviour:
   orderSlider: {fileID: 1273343427}
   artistText: {fileID: 1340187610}
   songTitleText: {fileID: 425342157}
-  songCountText: {fileID: 778661798}
+  songCountText: {fileID: 1346973260}
   videoIndicator: {fileID: 909180080}
   duetIndicator: {fileID: 1246195317}
   favoriteIndicator: {fileID: 1890362766}
@@ -2254,85 +2254,6 @@ MonoBehaviour:
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 0
   m_ReverseArrangement: 0
---- !u!1 &778661796
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 778661797}
-  - component: {fileID: 778661799}
-  - component: {fileID: 778661798}
-  m_Layer: 5
-  m_Name: Text
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &778661797
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 778661796}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 319813012}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &778661798
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 778661796}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_FontData:
-    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    m_FontSize: 14
-    m_FontStyle: 0
-    m_BestFit: 1
-    m_MinSize: 2
-    m_MaxSize: 15
-    m_Alignment: 5
-    m_AlignByGeometry: 0
-    m_RichText: 1
-    m_HorizontalOverflow: 1
-    m_VerticalOverflow: 0
-    m_LineSpacing: 1
-  m_Text: 5/100
---- !u!222 &778661799
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 778661796}
-  m_CullTransparentMesh: 0
 --- !u!1 &837359776
 GameObject:
   m_ObjectHideFlags: 0
@@ -3666,7 +3587,7 @@ Canvas:
   m_OverrideSorting: 0
   m_OverridePixelPerfect: 0
   m_SortingBucketNormalizedSize: 0
-  m_AdditionalShaderChannelsFlag: 0
+  m_AdditionalShaderChannelsFlag: 25
   m_SortingLayerID: 0
   m_SortingOrder: 0
   m_TargetDisplay: 0
@@ -4514,6 +4435,140 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1340187608}
   m_CullTransparentMesh: 0
+--- !u!1 &1346973257
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1346973258}
+  - component: {fileID: 1346973259}
+  - component: {fileID: 1346973260}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1346973258
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1346973257}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 319813012}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1346973259
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1346973257}
+  m_CullTransparentMesh: 0
+--- !u!114 &1346973260
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1346973257}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 9999/9999
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 14
+  m_fontSizeBase: 14
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 4
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 0
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 1
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: -0.25417355, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &1395254177
 GameObject:
   m_ObjectHideFlags: 0
@@ -5680,9 +5735,9 @@ MonoBehaviour:
   pivot: {x: 0.5, y: 0.5}
   localPosition: {x: -108.05235, y: 0, z: 616.995}
   anchoredPosition: {x: 0, y: 0}
-  position: {x: 16.83551, y: 10.673355, z: 0}
+  position: {x: 18.29303, y: 11.602524, z: 0}
   sizeDelta: {x: 0, y: 0}
-  size: {x: 33.890045, y: 21.42221}
+  size: {x: 33.890045, y: 21.431656}
 --- !u!114 &1616092804
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -7794,9 +7849,9 @@ MonoBehaviour:
   pivot: {x: 0.5, y: 0.5}
   localPosition: {x: 108.049995, y: 0, z: 616.995}
   anchoredPosition: {x: 0, y: 0}
-  position: {x: 780.1117, y: 10.652176, z: 0}
+  position: {x: 847.64966, y: 11.579498, z: 0}
   sizeDelta: {x: 0.000030517578, y: 0}
-  size: {x: 33.89006, y: 21.42221}
+  size: {x: 33.89006, y: 21.431656}
 --- !u!224 &6702459375939703474
 RectTransform:
   m_ObjectHideFlags: 0

--- a/UltraStar Play/Assets/Scenes/SongSelect/SongSelectSceneController.cs
+++ b/UltraStar Play/Assets/Scenes/SongSelect/SongSelectSceneController.cs
@@ -9,6 +9,7 @@ using System.Globalization;
 using System.Threading;
 using System.IO;
 using System;
+using TMPro;
 
 // Disable warning about fields that are never assigned, their values are injected.
 #pragma warning disable CS0649
@@ -41,7 +42,7 @@ public class SongSelectSceneController : MonoBehaviour, IOnHotSwapFinishedListen
     public ArtistText artistText;
     public Text songTitleText;
 
-    public Text songCountText;
+    public TMP_Text songCountText;
     public GameObject videoIndicator;
     public GameObject duetIndicator;
     public FavoriteIndicator favoriteIndicator;
@@ -63,6 +64,9 @@ public class SongSelectSceneController : MonoBehaviour, IOnHotSwapFinishedListen
 
     [Inject]
     private PlaylistManager playlistManager;
+
+    [Inject]
+    private Settings settings;
 
     public GameObject noSongsFoundMessage;
 
@@ -446,6 +450,11 @@ public class SongSelectSceneController : MonoBehaviour, IOnHotSwapFinishedListen
     public void UpdateFilteredSongs()
     {
         songRouletteController.SetSongs(GetFilteredSongMetas());
+
+        // Indicate filtered playlist via font style of song count
+        songCountText.fontStyle = playlistSlider.SelectedItem == null || playlistSlider.SelectedItem is UltraStarAllSongsPlaylist
+            ? FontStyles.Normal
+            : FontStyles.Underline;
     }
 
     private bool TryExecuteSpecialSearchSyntax(string searchText)


### PR DESCRIPTION
### What does this PR do?

See title.

**Motivation**
I was confused because the game did not show all of my songs.
So I started debugging.
And then I realized: Damn, I just have a playlist active 🤦 !
(Note that the last used playlist is persisted)

If your own software is confusing you (although correct), then this might be bad UX.

Thus, I guess some hint is required to tell users that the song list is filtered and not showing all songs.
Changing the font of the song-count-label is my approach to this.

The default Unity Text does not support underline style. So I replaced it with one from TextMesh Pro.