### PR TITLE
Serilog for logging

### DIFF
--- a/UltraStar Play/Assets/.gitignore
+++ b/UltraStar Play/Assets/.gitignore
@@ -30,3 +30,8 @@ Plugins/TexMesh Pro.meta
 
 Plugins/UniInject/
 Plugins/UniInject.meta
+
+Plugins/Serilog/Serilog/
+Plugins/Serilog/Serilog.meta
+Plugins/Serilog/Serilog.Sinks.File/
+Plugins/Serilog/Serilog.Sinks.File.meta

--- a/UltraStar Play/Assets/Common/ApplicationManager.cs
+++ b/UltraStar Play/Assets/Common/ApplicationManager.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -31,6 +30,16 @@ public class ApplicationManager : MonoBehaviour
         {
             Application.targetFrameRate = targetFrameRate;
         }
+    }
+
+    void OnEnable()
+    {
+        Application.logMessageReceived += Log.HandleUnityLog;
+    }
+
+    void OnDisable()
+    {
+        Application.logMessageReceived -= Log.HandleUnityLog;
     }
 
     public bool HasCommandLineArgument(string argumentName)

--- a/UltraStar Play/Assets/Common/Common.asmdef
+++ b/UltraStar Play/Assets/Common/Common.asmdef
@@ -1,6 +1,7 @@
 {
     "name": "Common",
     "references": [
+        "Serilog",
         "Plugins",
         "UniRx",
         "UniInject",

--- a/UltraStar Play/Assets/Common/Logging.meta
+++ b/UltraStar Play/Assets/Common/Logging.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1ff9d4c9d43f67347b1b7c63ecdc788f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UltraStar Play/Assets/Common/Logging/Log.cs
+++ b/UltraStar Play/Assets/Common/Logging/Log.cs
@@ -62,9 +62,6 @@ public static class Log
 
         switch (type)
         {
-            case LogType.Log:
-                loggerWithContext.Information(logString);
-                break;
             case LogType.Warning:
                 loggerWithContext.Warning(logString);
                 break;
@@ -72,6 +69,9 @@ public static class Log
             case LogType.Error:
             case LogType.Exception:
                 loggerWithContext.Error(logString + stackTrace);
+                break;
+            default:
+                loggerWithContext.Information(logString);
                 break;
         }
     }

--- a/UltraStar Play/Assets/Common/Logging/Log.cs
+++ b/UltraStar Play/Assets/Common/Logging/Log.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.IO;
+using Serilog;
+using Serilog.Events;
+using UnityEngine;
+
+public static class Log
+{
+    private static readonly string logFileFolder = Application.persistentDataPath + "/Logs";
+    private static readonly string logFilePath = logFileFolder + "/UltraStarPlay.log";
+
+    public static Serilog.ILogger Logger { get; private set; }
+
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+    static void Init()
+    {
+        Logger = CreateLogger();
+    }
+
+    private static Serilog.ILogger CreateLogger()
+    {
+        if (!Directory.Exists(logFileFolder))
+        {
+            Directory.CreateDirectory(logFileFolder);
+        }
+        int fileSizeLimitBytes = 250 * 1000 * 1000; // 250 MB
+        LoggerConfiguration loggerConfiguration = new LoggerConfiguration()
+            .MinimumLevel.Information()
+            .Enrich.FromLogContext()
+            .Enrich.With<UnityStackTraceEnricher>()
+            .WriteTo.Sink(new UnityLogEventSink())
+            .WriteTo.File(
+                logFilePath, // path
+                LogEventLevel.Verbose, // restrictedToMinimumLevel
+                "{Timestamp:yyyy-MM-dd HH:mm:ss.fff} [{Level:u3}] {Message:lj}{NewLine}{StackTrace}", // outputTemplate
+                null, // formatProvider
+                fileSizeLimitBytes, // fileSizeLimitBytes
+                null, // levelSwitch
+                false, // buffered
+                false, // shared
+                null, // flushToDiskInterval
+                RollingInterval.Day, // rollingInterval
+                false, // rollOnFileSizeLimit
+                5, // retainedFileCountLimit
+                System.Text.Encoding.UTF8, // Encoding
+                null); // FileLifecycleHooks
+
+        Serilog.ILogger logger = loggerConfiguration.CreateLogger();
+        logger.Information("===== Initialized Serilog Logger =====");
+        return logger;
+    }
+
+    public static void HandleUnityLog(string logString, string stackTrace, LogType type)
+    {
+        if (logString.EndsWith(UnityLogEventSink.unityLogEventSinkMarker))
+        {
+            // Has already been logged to the Unity Console.
+            return;
+        }
+
+        Serilog.ILogger loggerWithContext = Logger.ForContext(UnityLogEventSink.skipUnityLogEventSinkPropertyName, true);
+
+        switch (type)
+        {
+            case LogType.Log:
+                loggerWithContext.Information(logString);
+                break;
+            case LogType.Warning:
+                loggerWithContext.Warning(logString);
+                break;
+            case LogType.Assert:
+            case LogType.Error:
+            case LogType.Exception:
+                loggerWithContext.Error(logString + stackTrace);
+                break;
+        }
+    }
+}

--- a/UltraStar Play/Assets/Common/Logging/Log.cs.meta
+++ b/UltraStar Play/Assets/Common/Logging/Log.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 43da8d597c8f1c744aa4e2b0498ac6cb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UltraStar Play/Assets/Common/Logging/ScalarValueEnricher.cs
+++ b/UltraStar Play/Assets/Common/Logging/ScalarValueEnricher.cs
@@ -1,0 +1,21 @@
+﻿using Serilog.Core;
+using Serilog.Events;
+
+/**
+ * Passes a value to the logging sinks, without the value beeing serialized to a string
+ * (i.e. the original object reference is still available in the logging sink).
+ */
+public class ScalarValueEnricher : ILogEventEnricher
+{
+    protected readonly LogEventProperty property;
+
+    public ScalarValueEnricher(string name, object value)
+    {
+        property = new LogEventProperty(name, new ScalarValue(value));
+    }
+
+    public void Enrich(LogEvent evt, ILogEventPropertyFactory _)
+    {
+        evt.AddPropertyIfAbsent(property);
+    }
+}

--- a/UltraStar Play/Assets/Common/Logging/ScalarValueEnricher.cs.meta
+++ b/UltraStar Play/Assets/Common/Logging/ScalarValueEnricher.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 884c3a8ad8238ac49a86d59fd9124df9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UltraStar Play/Assets/Common/Logging/UnityLogEventSink.cs
+++ b/UltraStar Play/Assets/Common/Logging/UnityLogEventSink.cs
@@ -1,0 +1,79 @@
+﻿using System.IO;
+using Serilog.Context;
+using Serilog.Core;
+using Serilog.Events;
+using Serilog.Formatting;
+using Serilog.Formatting.Display;
+using UnityEngine;
+
+public sealed class UnityLogEventSink : ILogEventSink
+{
+    private static readonly string defaultOutputTemplate = "[{Level:u3}] {Message:lj}{NewLine}{StackTrace}";
+
+    public static readonly string unityLogEventSinkMarker = "\n(UnityLogEventSink)";
+    public static readonly string skipUnityLogEventSinkPropertyName = "skipUnityLogEventSink";
+
+    private readonly ITextFormatter formatter;
+
+    public UnityLogEventSink()
+        : this(new MessageTemplateTextFormatter(defaultOutputTemplate, null))
+    {
+    }
+
+    public UnityLogEventSink(ITextFormatter formatter)
+    {
+        this.formatter = formatter;
+    }
+
+    public void Emit(LogEvent logEvent)
+    {
+        if (logEvent.Properties.ContainsKey(skipUnityLogEventSinkPropertyName))
+        {
+            return;
+        }
+
+        using (StringWriter stringBuffer = new StringWriter())
+        {
+            formatter.Format(logEvent, stringBuffer);
+            // Need to escape curly braces because Debug.LogFormat is used
+            string logString = stringBuffer.ToString().Trim()
+                .Replace("{","{{")
+                .Replace("}", "}}")
+                + unityLogEventSinkMarker;
+            LogType logType = GetUnityLogType(logEvent);
+            UnityEngine.Object contextObject = GetUnityEngineContextObject(logEvent);
+            Debug.LogFormat(logType, LogOption.NoStacktrace, contextObject, logString);
+        }
+    }
+
+    private UnityEngine.Object GetUnityEngineContextObject(LogEvent logEvent)
+    {
+        if (logEvent.Properties.TryGetValue(UnityObjectEnricher.unityObjectPropertyName, out LogEventPropertyValue logEventPropertyValue))
+        {
+            if (logEventPropertyValue is ScalarValue scalarValue)
+            {
+                return scalarValue.Value as UnityEngine.Object;
+            }
+        }
+        return null;
+    }
+
+    private static LogType GetUnityLogType(LogEvent logEvent)
+    {
+        switch (logEvent.Level)
+        {
+            case LogEventLevel.Verbose:
+            case LogEventLevel.Debug:
+            case LogEventLevel.Information:
+                return LogType.Log;
+            case LogEventLevel.Warning:
+                return LogType.Warning;
+            case LogEventLevel.Error:
+            case LogEventLevel.Fatal:
+                return logEvent.Exception != null ? LogType.Exception : LogType.Error;
+            default:
+                Debug.LogError("Unkown LogLevel" + logEvent.Level);
+                return LogType.Log;
+        }
+    }
+}

--- a/UltraStar Play/Assets/Common/Logging/UnityLogEventSink.cs
+++ b/UltraStar Play/Assets/Common/Logging/UnityLogEventSink.cs
@@ -48,12 +48,10 @@ public sealed class UnityLogEventSink : ILogEventSink
 
     private UnityEngine.Object GetUnityEngineContextObject(LogEvent logEvent)
     {
-        if (logEvent.Properties.TryGetValue(UnityObjectEnricher.unityObjectPropertyName, out LogEventPropertyValue logEventPropertyValue))
+        if (logEvent.Properties.TryGetValue(UnityObjectEnricher.unityObjectPropertyName, out LogEventPropertyValue logEventPropertyValue)
+            && logEventPropertyValue is ScalarValue scalarValue)
         {
-            if (logEventPropertyValue is ScalarValue scalarValue)
-            {
-                return scalarValue.Value as UnityEngine.Object;
-            }
+            return scalarValue.Value as UnityEngine.Object;
         }
         return null;
     }

--- a/UltraStar Play/Assets/Common/Logging/UnityLogEventSink.cs.meta
+++ b/UltraStar Play/Assets/Common/Logging/UnityLogEventSink.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 87b34bd358f170e499e27461193e44e1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UltraStar Play/Assets/Common/Logging/UnityObjectEnricher.cs
+++ b/UltraStar Play/Assets/Common/Logging/UnityObjectEnricher.cs
@@ -1,0 +1,24 @@
+﻿/**
+ * Holds a UnityEngine.Object (e.g. GameObject) to use Serilog logging statement
+ * and still have Unity's Debug.Log method be called with a context object.
+ * The context object will be highlighted in the inspector, when the log message is clicked in the Unity Console.
+ * 
+ * Usage:
+ * <pre>
+ * Log.Logger.ForContext(new UnityObjectEnricher(gameObject)).Information("This is an info with context");
+ * 
+ * using (LogContext.Push(new UnityObjectEnricher(gameObject)))
+ * {
+ *     Log.Logger.Information("This is an info with context");
+ * }
+ * </pre>
+ */
+public class UnityObjectEnricher : ScalarValueEnricher
+{
+    public static readonly string unityObjectPropertyName = "unityObject";
+
+    public UnityObjectEnricher(UnityEngine.Object value)
+        : base(unityObjectPropertyName, value)
+    {
+    }
+}

--- a/UltraStar Play/Assets/Common/Logging/UnityObjectEnricher.cs.meta
+++ b/UltraStar Play/Assets/Common/Logging/UnityObjectEnricher.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6f2e026e98892e940b96098c110b5b36
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UltraStar Play/Assets/Common/Logging/UnityStackTraceEnricher.cs
+++ b/UltraStar Play/Assets/Common/Logging/UnityStackTraceEnricher.cs
@@ -1,0 +1,20 @@
+﻿using Serilog.Core;
+using Serilog.Events;
+using UnityEngine;
+
+public class UnityStackTraceEnricher : ILogEventEnricher
+{
+    private static readonly string indentation = "    ";
+
+    public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+    {
+        if (logEvent.Exception != null)
+        {
+            string stackTraceIndented = indentation + StackTraceUtility.ExtractStringFromException(logEvent.Exception)
+                .Replace("\r\n", "\n")
+                .Replace("\n", "\n" + indentation);
+            logEvent.AddOrUpdateProperty(
+                new LogEventProperty("StackTrace", new ScalarValue(stackTraceIndented)));
+        }
+    }
+}

--- a/UltraStar Play/Assets/Common/Logging/UnityStackTraceEnricher.cs.meta
+++ b/UltraStar Play/Assets/Common/Logging/UnityStackTraceEnricher.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 540090951f4f3cd46b222db6c3fffacb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UltraStar Play/Assets/Plugins/Serilog.meta
+++ b/UltraStar Play/Assets/Plugins/Serilog.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b6766f070239df44fbcac2e471f897c4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UltraStar Play/Assets/Plugins/Serilog/Serilog.asmdef
+++ b/UltraStar Play/Assets/Plugins/Serilog/Serilog.asmdef
@@ -1,0 +1,3 @@
+{
+    "name": "Serilog"
+}

--- a/UltraStar Play/Assets/Plugins/Serilog/Serilog.asmdef.meta
+++ b/UltraStar Play/Assets/Plugins/Serilog/Serilog.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3dd5bd1f8f8262f439256f2e763948eb
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UltraStar Play/Assets/Scenes/Loading/LoadingSceneController.cs
+++ b/UltraStar Play/Assets/Scenes/Loading/LoadingSceneController.cs
@@ -10,12 +10,12 @@ public class LoadingSceneController : MonoBehaviour
         Screen.sleepTimeout = (int)0f;
         Screen.sleepTimeout = SleepTimeout.NeverSleep;
         // The settings are loaded on access.
-        string jsonSettings = JsonConverter.ToJson(SettingsManager.Instance.Settings, true);
-        Debug.Log("loaded settings:" + jsonSettings);
+        string jsonSettings = JsonConverter.ToJson(SettingsManager.Instance.Settings, false);
+        Log.Logger.Information("loaded settings:" + jsonSettings);
 
         // The SongMetas are loaded on access.
         SongMetaManager.Instance.ScanFilesIfNotDoneYet();
-        Debug.Log("started loading songs.");
+        Log.Logger.Information("started loading songs.");
 
         // Extract StreamingAssets on Android from the JAR
         AndroidStreamingAssets.Extract();

--- a/UltraStar Play/Assets/Scenes/Scenes.asmdef
+++ b/UltraStar Play/Assets/Scenes/Scenes.asmdef
@@ -1,6 +1,7 @@
 {
     "name": "Scenes",
     "references": [
+        "Serilog",
         "Plugins",
         "UniRx",
         "UniInject",

--- a/UltraStar Play/ProjectSettings/ProjectSettings.asset
+++ b/UltraStar Play/ProjectSettings/ProjectSettings.asset
@@ -657,6 +657,9 @@ PlayerSettings:
   webGLDecompressionFallback: 0
   scriptingDefineSymbols:
     1: OS_MUTEX
+    4: OS_MUTEX
+    7: OS_MUTEX
+    13: OS_MUTEX
   platformArchitecture: {}
   scriptingBackend: {}
   il2cppCompilerConfiguration: {}

--- a/UltraStar Play/ProjectSettings/ProjectSettings.asset
+++ b/UltraStar Play/ProjectSettings/ProjectSettings.asset
@@ -655,7 +655,8 @@ PlayerSettings:
   webGLLinkerTarget: 0
   webGLThreadsSupport: 0
   webGLDecompressionFallback: 0
-  scriptingDefineSymbols: {}
+  scriptingDefineSymbols:
+    1: OS_MUTEX
   platformArchitecture: {}
   scriptingBackend: {}
   il2cppCompilerConfiguration: {}

--- a/tools/download-dependencies/download-dependencies.sh
+++ b/tools/download-dependencies/download-dependencies.sh
@@ -7,3 +7,4 @@ sh download-csharpsynthforunity.sh
 sh download-text-mesh-pro-resources.sh
 sh download-sharpziplib.sh
 sh download-uniinject.sh
+sh download-serilog.sh

--- a/tools/download-dependencies/download-serilog.sh
+++ b/tools/download-dependencies/download-serilog.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+
+old_dir=$(pwd)
+
+cd "../../UltraStar Play/Assets/Plugins/Serilog"
+echo "Removing old Serilog (main) folder..."
+rm -rf Serilog
+mkdir Serilog
+cd Serilog
+
+echo "Cloning Serilog from remote..."
+git init
+git remote add origin https://github.com/serilog/serilog.git
+git config core.sparsecheckout true
+echo "LICENSE" >> .git/info/sparse-checkout
+echo "src/Serilog/*" >> .git/info/sparse-checkout
+git pull --depth=200 origin master
+# Commit from 13 October 2019 (release 2.9.0): 655778f74384f682d2c8705ab4883c39ef17e44d
+git checkout 655778f74384f682d2c8705ab4883c39ef17e44d
+
+echo "Moving downloaded files to correct position for this project..."
+mv -v src/Serilog/* ./
+rm -rf ./src
+rm -rf .git
+rm Properties/AssemblyInfo.cs
+
+cd "$old_dir"
+echo "Downloading Serilog (main) done"
+echo ""
+
+#######################################################################
+old_dir=$(pwd)
+
+cd "../../UltraStar Play/Assets/Plugins/Serilog"
+echo "Removing old Serilog.Sinks.File folder..."
+rm -rf Serilog.Sinks.File
+mkdir Serilog.Sinks.File
+cd Serilog.Sinks.File
+
+echo "Cloning Serilog.Sinks.File from remote..."
+git init
+git remote add origin https://github.com/serilog/serilog-sinks-file.git
+git config core.sparsecheckout true
+echo "LICENSE" >> .git/info/sparse-checkout
+echo "src/Serilog.Sinks.File/*" >> .git/info/sparse-checkout
+git pull --depth=500 origin master
+# Commit from 17 October 2019 (release 4.1.0): 272085f4c9440e62448b65829ad35cc3dea15ab1
+git checkout 272085f4c9440e62448b65829ad35cc3dea15ab1
+
+echo "Moving downloaded files to correct position for this project..."
+mv -v src/Serilog.Sinks.File/* ./
+rm -rf ./src
+rm -rf .git
+rm Properties/AssemblyInfo.cs
+
+cd "$old_dir"
+echo "Downloading Serilog.Sinks.File done"
+echo ""


### PR DESCRIPTION
### What does this PR do?

Add Serilog library for logging.

I researched logging libs for C# and found that NLog and Serilog are modern tools for this task.
I tried both. NLog has a big repo (5 MB only the source folder) with everything in it and I got lots of compiler issues.
In contrast, Serilog has a dedicated repo for every sink (i.e. logging target) such that the repos themselves are pretty small (700 KB total for core and file-sink source). I also had only few compiler issues.

Thus I chose Serilog.

- Added define symbol OS_MUTEX for Serilog compilation
    - This defines which SharedFileSink implementation is used [OsMutex](https://github.com/serilog/serilog-sinks-file/blob/06e457a3d19b4a0cb00717a0bfd5c3be2d2016fe/src/Serilog.Sinks.File/Sinks/File/SharedFileSink.OSMutex.cs) or [AtomicAppend](https://github.com/serilog/serilog-sinks-file/blob/06e457a3d19b4a0cb00717a0bfd5c3be2d2016fe/src/Serilog.Sinks.File/Sinks/File/SharedFileSink.AtomicAppend.cs)
    - I don't really know how the implementations differ, but `shared` parameter in config is false so I guess we do not need this feature anyway.
- Configured Serilog in Log.cs and can be accessed via `Log.Logger`
    - use rolling-file-configuration. Logs are saved to `Application.persistentDataPath + "/Logs"`. Log file changes daily, max 5 files, max 250 MB.
    - For exceptions, the stacke trace is appended (see UnityStackTraceEnricher)
- normal Unity logging is also passed to Serilog (via Application.logMessageReceived)
- Serilog logging is also passed to Unity logging
    - To prevent cycles, a marker is added to the log message (depending on the original source this is `unityLogEventSinkMarker` or `skipUnityLogEventSinkPropertyName`)

This is a initial, basic logging configuration that could be extended to send logs (or only exceptions) to a logging service for analysis, statistics etc. However, I think it is sufficient for our purpose.

### Closes Issue(s)

close #207 