### PR TITLE
improved fuzzy search in SongSelectScene

### DIFF
--- a/UltraStar Play/Assets/Common/Scene/CommonSceneObjects.prefab
+++ b/UltraStar Play/Assets/Common/Scene/CommonSceneObjects.prefab
@@ -70,7 +70,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 41156639313405361}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -310.12363, y: -354.77222, z: 109.334206}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 8069444317427349030}
@@ -614,7 +614,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1197462286522570267}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 310.12363, y: 354.77222, z: -119.334206}
+  m_LocalPosition: {x: 0, y: 354.77222, z: -119.334206}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 301966391878918758}

--- a/UltraStar Play/Assets/Scenes/Highscore/HighscoreScene.unity
+++ b/UltraStar Play/Assets/Scenes/Highscore/HighscoreScene.unity
@@ -478,6 +478,18 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   direction: 1
+--- !u!114 &141673550 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 5124115183525111794, guid: be0e3235464c346458a464603cce47c0,
+    type: 3}
+  m_PrefabInstance: {fileID: 141673545}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 141673547}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &335886005
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1130,6 +1142,7 @@ GameObject:
   - component: {fileID: 1335080095}
   - component: {fileID: 1335080094}
   - component: {fileID: 1335080093}
+  - component: {fileID: 1335080097}
   m_Layer: 5
   m_Name: ContinueButton
   m_TagString: Untagged
@@ -1251,6 +1264,18 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1335080091}
   m_CullTransparentMesh: 1
+--- !u!114 &1335080097
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1335080091}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: da2105757e00a18428ad1ed75c8d427b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1380486259
 GameObject:
   m_ObjectHideFlags: 0
@@ -1926,7 +1951,7 @@ GameObject:
   - component: {fileID: 2064943531}
   - component: {fileID: 2064943530}
   m_Layer: 0
-  m_Name: HighscoreSceneKeyboardController
+  m_Name: HighscoreSceneInputController
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -1944,6 +1969,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 62443f1661c7f0c459f62338ddb09f17, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  continueButton: {fileID: 1335080094}
+  nextDifficultyButton: {fileID: 141673550}
 --- !u!4 &2064943531
 Transform:
   m_ObjectHideFlags: 0

--- a/UltraStar Play/Assets/Scenes/SingingResults/SingingResultsScene.unity
+++ b/UltraStar Play/Assets/Scenes/SingingResults/SingingResultsScene.unity
@@ -565,7 +565,7 @@ PrefabInstance:
     - target: {fileID: 5124115183525111805, guid: be0e3235464c346458a464603cce47c0,
         type: 3}
       propertyPath: m_RootOrder
-      value: 5
+      value: 4
       objectReference: {fileID: 0}
     - target: {fileID: 5124115183525111805, guid: be0e3235464c346458a464603cce47c0,
         type: 3}
@@ -712,16 +712,16 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   key: graph_button_label
---- !u!114 &369191791
+--- !u!114 &369191796 stripped
 MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 5124115183525111794, guid: be0e3235464c346458a464603cce47c0,
+    type: 3}
+  m_PrefabInstance: {fileID: 369191785}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 369191787}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: da2105757e00a18428ad1ed75c8d427b, type: 3}
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &452536625
@@ -3196,6 +3196,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 485880196d55fc044a8ffe1fba13ba6e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  continueButton: {fileID: 1741756472}
+  toggleStatisticsButton: {fileID: 369191796}
 --- !u!1 &1450078085
 GameObject:
   m_ObjectHideFlags: 0
@@ -4068,6 +4070,7 @@ GameObject:
   - component: {fileID: 1741756473}
   - component: {fileID: 1741756472}
   - component: {fileID: 1741756475}
+  - component: {fileID: 1741756476}
   m_Layer: 5
   m_Name: ContinueButton
   m_TagString: Untagged
@@ -4187,6 +4190,18 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: d6d950d1677eb834a8a0db8d0855fe71, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1741756476
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1741756470}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: da2105757e00a18428ad1ed75c8d427b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &1779431420

--- a/UltraStar Play/Assets/Scenes/SingingResults/SingingResultsSceneInputControl.cs
+++ b/UltraStar Play/Assets/Scenes/SingingResults/SingingResultsSceneInputControl.cs
@@ -2,19 +2,33 @@
 using System.Collections.Generic;
 using UniInject;
 using UnityEngine;
+using UnityEngine.UI;
 using UnityEngine.EventSystems;
 using UniRx;
+using UnityEngine.InputSystem;
 
 // Disable warning about fields that are never assigned, their values are injected.
 #pragma warning disable CS0649
 
 public class SingingResultsSceneInputControl : MonoBehaviour, INeedInjection
 {
+    [InjectedInInspector]
+    public Button continueButton;
+    
+    [InjectedInInspector]
+    public Button toggleStatisticsButton;
+    
     [Inject]
     private SingingResultsSceneController singingResultsSceneController;
-
+    
+    [Inject]
+    private EventSystem eventSystem;
+    
     private void Start()
     {
+        // Custom navigation implementation in this scene
+        eventSystem.sendNavigationEvents = false;
+        
         InputManager.GetInputAction(R.InputActions.usplay_toggleResultGraph).PerformedAsObservable()
             .Subscribe(_ => singingResultsSceneController.ToggleStatistics());
 
@@ -24,5 +38,36 @@ public class SingingResultsSceneInputControl : MonoBehaviour, INeedInjection
             .Subscribe(_ => singingResultsSceneController.FinishScene());
         InputManager.GetInputAction(R.InputActions.usplay_space).PerformedAsObservable()
             .Subscribe(_ => singingResultsSceneController.FinishScene());
+            
+        InputManager.GetInputAction(R.InputActions.ui_navigate).PerformedAsObservable()
+            .Subscribe(_  => OnNavigate());
+        InputManager.GetInputAction(R.InputActions.ui_submit).PerformedAsObservable()
+            .Subscribe(_ => OnSubmit());
+
+    }
+
+    private void OnSubmit()
+    {
+        if (eventSystem.currentSelectedGameObject == null)
+        {
+            return;
+        }
+        Button selectedButton = eventSystem.currentSelectedGameObject.GetComponent<Button>();
+        if (selectedButton == null)
+        {
+            return;
+        }
+        selectedButton.OnSubmit(new BaseEventData(eventSystem));
+    }
+
+    private void OnNavigate()
+    {
+        // Toggle between buttons
+        if (eventSystem.currentSelectedGameObject == toggleStatisticsButton.gameObject)
+        {
+            continueButton.Select();
+            return;
+        }
+        toggleStatisticsButton.Select();
     }
 }

--- a/UltraStar Play/Assets/Scenes/SongSelect/SongSelectFuzzySearchText.cs
+++ b/UltraStar Play/Assets/Scenes/SongSelect/SongSelectFuzzySearchText.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using UnityEngine.UI;
+using UniInject;
+using UniRx;
+
+// Disable warning about fields that are never assigned, their values are injected.
+#pragma warning disable CS0649
+
+public class SongSelectFuzzySearchText : MonoBehaviour, INeedInjection
+{
+    [Inject(searchMethod = SearchMethods.GetComponentInChildren)]
+    private Text uiText;
+    
+    [Inject]
+    private SongSelectSceneInputControl songSelectSceneInputControl;
+    
+	private void Start()
+    {
+        uiText.text = "";
+        
+        songSelectSceneInputControl.FuzzySearchText
+            .Subscribe(newFuzzySearchText => uiText.text = newFuzzySearchText);
+    }
+}

--- a/UltraStar Play/Assets/Scenes/SongSelect/SongSelectFuzzySearchText.cs.meta
+++ b/UltraStar Play/Assets/Scenes/SongSelect/SongSelectFuzzySearchText.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a8dd248cec5a5804dbc3edd3125cbb2f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UltraStar Play/Assets/Scenes/SongSelect/SongSelectScene.unity
+++ b/UltraStar Play/Assets/Scenes/SongSelect/SongSelectScene.unity
@@ -2019,6 +2019,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7399b3bf3bdbac04483cae7688035fcf, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  songSelectSceneInputControl: {fileID: 1490683137}
   songAudioPlayer: {fileID: 1830530624}
   songVideoPlayer: {fileID: 216611794}
   songRouletteController: {fileID: 261392374}
@@ -3751,6 +3752,7 @@ RectTransform:
   - {fileID: 6702459375858507009}
   - {fileID: 1273343426}
   - {fileID: 1030852802}
+  - {fileID: 1853751359}
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -5303,6 +5305,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d193deecfd36cb84886c844c4f683c78, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  fuzzySearchText:
+    value: 
 --- !u!4 &1490683138
 Transform:
   m_ObjectHideFlags: 0
@@ -6825,6 +6829,98 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1851953695}
   m_CullTransparentMesh: 0
+--- !u!1 &1853751358
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1853751359}
+  - component: {fileID: 1853751361}
+  - component: {fileID: 1853751360}
+  - component: {fileID: 1853751362}
+  m_Layer: 5
+  m_Name: FuzzySearchText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1853751359
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1853751358}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1032696880}
+  m_RootOrder: 13
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.36406276, y: 0.8366446}
+  m_AnchorMax: {x: 0.6453254, y: 0.9033113}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1853751360
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1853751358}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.90588236, g: 0.66764325, b: 0.2588235, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 20
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 0
+    m_MaxSize: 143
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 1
+    m_LineSpacing: 1
+  m_Text: FuuzySearchText
+--- !u!222 &1853751361
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1853751358}
+  m_CullTransparentMesh: 1
+--- !u!114 &1853751362
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1853751358}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a8dd248cec5a5804dbc3edd3125cbb2f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1860854024
 GameObject:
   m_ObjectHideFlags: 0

--- a/UltraStar Play/Assets/Scenes/SongSelect/SongSelectSceneController.cs
+++ b/UltraStar Play/Assets/Scenes/SongSelect/SongSelectSceneController.cs
@@ -25,6 +25,9 @@ public class SongSelectSceneController : MonoBehaviour, IOnHotSwapFinishedListen
     }
 
     [InjectedInInspector]
+    public SongSelectSceneInputControl songSelectSceneInputControl;
+    
+    [InjectedInInspector]
     public SongAudioPlayer songAudioPlayer;
 
     [InjectedInInspector]
@@ -179,18 +182,45 @@ public class SongSelectSceneController : MonoBehaviour, IOnHotSwapFinishedListen
         duetIndicator.SetActive(isDuet);
     }
 
-    public void JumpToSongWhereTitleStartsWith(string text)
+    public void DoFuzzySearch(string text)
     {
-        string textToLowerNoWhitespace = text.ToLowerInvariant().Replace(" ", "");
-        SongMeta match = songRouletteController.Find(it =>
+        string searchTextToLowerNoWhitespace = text.ToLowerInvariant().Replace(" ", "");
+        
+        // Search title that starts with the text
+        SongMeta titleStartsWithMatch = songRouletteController.Find(it =>
         {
             string titleToLowerNoWhitespace = it.Title.ToLowerInvariant().Replace(" ", "");
-            return titleToLowerNoWhitespace.StartsWith(textToLowerNoWhitespace);
+            return titleToLowerNoWhitespace.StartsWith(searchTextToLowerNoWhitespace);
         });
-
-        if (match != null)
+        if (titleStartsWithMatch != null)
         {
-            songRouletteController.SelectSong(match);
+            songRouletteController.SelectSong(titleStartsWithMatch);
+            return;
+        }
+        
+        // Search artist that starts with the text
+        SongMeta artistStartsWithMatch = songRouletteController.Find(it =>
+        {
+            string artistToLowerNoWhitespace = it.Artist.ToLowerInvariant().Replace(" ", "");
+            return artistToLowerNoWhitespace.StartsWith(searchTextToLowerNoWhitespace);
+        });
+        if (artistStartsWithMatch != null)
+        {
+            songRouletteController.SelectSong(artistStartsWithMatch);
+            return;
+        }
+        
+        // Search title or artist contains the text
+        SongMeta artistOrTitleContainsMatch = songRouletteController.Find(it =>
+        {
+            string artistToLowerNoWhitespace = it.Artist.ToLowerInvariant().Replace(" ", "");
+            string titleToLowerNoWhitespace = it.Title.ToLowerInvariant().Replace(" ", "");
+            return artistToLowerNoWhitespace.Contains(searchTextToLowerNoWhitespace)
+                || titleToLowerNoWhitespace.Contains(searchTextToLowerNoWhitespace);
+        });
+        if (artistOrTitleContainsMatch != null)
+        {
+            songRouletteController.SelectSong(artistOrTitleContainsMatch);
         }
     }
 
@@ -417,6 +447,7 @@ public class SongSelectSceneController : MonoBehaviour, IOnHotSwapFinishedListen
         BindingBuilder bb = new BindingBuilder();
         bb.BindExistingInstance(this);
         bb.BindExistingInstance(songRouletteController);
+        bb.BindExistingInstance(songSelectSceneInputControl);
         bb.BindExistingInstance(songAudioPlayer);
         bb.BindExistingInstance(songVideoPlayer);
         bb.BindExistingInstance(playlistSlider);

--- a/UltraStar Play/Assets/Scenes/SongSelect/SongSelectSceneInputControl.cs
+++ b/UltraStar Play/Assets/Scenes/SongSelect/SongSelectSceneInputControl.cs
@@ -20,7 +20,7 @@ public class SongSelectSceneInputControl : MonoBehaviour, INeedInjection
     [Inject]
     private SongSelectSceneControlNavigator songSelectSceneControlNavigator;
 
-    private ReactiveProperty<string> fuzzySearchText = new ReactiveProperty<string>("");
+    private readonly ReactiveProperty<string> fuzzySearchText = new ReactiveProperty<string>("");
     public IObservable<string> FuzzySearchText => fuzzySearchText;
     private float fuzzySearchLastInputTimeInSeconds;
     private static readonly float fuzzySearchResetTimeInSeconds = 0.75f;


### PR DESCRIPTION
This is a small PR.

The "fuzzy search" directly jumps to the song that matches the entered text (in contrast to the normal search, which filters the songs).

New features:
- show the current fuzzy-search-text in the UI
- Extended search if nothing found.
    1. search by "title starts with"
    2. search by "artist starts with"
    3. search by "artist or title contains"

