### PR TITLE
travis config: perform docker login before pulling any images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ before_install:
   - chmod +x ./tools/download-dependencies/*.sh
   - export -f travis_fold
   - (cd tools/download-dependencies/; sh download-dependencies.sh)
+  - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
   - docker pull $IMAGE_NAME
 
 jobs:


### PR DESCRIPTION
### What does this PR do?

See title.
I already created a Docker account for UltraStar Play and added the credentials to travis.

This PR is only to check that the Travis build succeeds.

### Closes Issue(s)

#224 