### PR TITLE
Anst/fixes

### DIFF
--- a/UltraStar Play/Assets/Common/I18N/I18NManager.cs
+++ b/UltraStar Play/Assets/Common/I18N/I18NManager.cs
@@ -218,4 +218,21 @@ public class I18NManager : MonoBehaviour, INeedInjection
         path = ApplicationUtils.GetStreamingAssetsPath(path);
         return path;
     }
+    
+    public List<SystemLanguage> GetTranslatedLanguages()
+    {
+        HashSet<SystemLanguage> translatedLanguages = new HashSet<SystemLanguage> { SystemLanguage.English };
+        foreach (SystemLanguage systemLanguage in EnumUtils.GetValuesAsList<SystemLanguage>())
+        {
+            string suffix = GetCountryCodeSuffixForPropertiesFile(systemLanguage);
+            string propertiesFilePath = GetPropertiesFilePath(PropertiesFileName + suffix);
+            if (File.Exists(propertiesFilePath))
+            {
+                translatedLanguages.Add(systemLanguage);
+            }
+        }
+        return translatedLanguages
+            .OrderBy(it => it.ToString())
+            .ToList();
+    }
 }

--- a/UltraStar Play/Assets/Common/I18N/LanguageHelper.cs
+++ b/UltraStar Play/Assets/Common/I18N/LanguageHelper.cs
@@ -23,7 +23,9 @@ public static class LanguageHelper
             case SystemLanguage.Belarusian: return "BY";
             case SystemLanguage.Bulgarian: return "BG";
             case SystemLanguage.Catalan: return "CA";
-            case SystemLanguage.Chinese: return "ZH";
+            case SystemLanguage.Chinese:
+            case SystemLanguage.ChineseSimplified:
+            case SystemLanguage.ChineseTraditional: return "ZH";
             case SystemLanguage.Czech: return "CS";
             case SystemLanguage.Danish: return "DA";
             case SystemLanguage.Dutch: return "NL";

--- a/UltraStar Play/Assets/Common/Model/Song/SongMetaUtils.cs
+++ b/UltraStar Play/Assets/Common/Model/Song/SongMetaUtils.cs
@@ -46,8 +46,9 @@ public static class SongMetaUtils
     public static Voice GetOrCreateVoice(SongMeta songMeta, string voiceName)
     {
         Voice matchingVoice = songMeta.GetVoices()
-            .Where(it => it.Name == voiceName || (voiceName.IsNullOrEmpty() && it.Name == Voice.soloVoiceName))
-            .FirstOrDefault();
+            .FirstOrDefault(voice => voice.Name == voiceName
+                                     || (voiceName.IsNullOrEmpty() && voice.Name == Voice.firstVoiceName)
+                                     || (voiceName == Voice.firstVoiceName && voice.Name.IsNullOrEmpty()));
         if (matchingVoice != null)
         {
             return matchingVoice;

--- a/UltraStar Play/Assets/Common/UI/ContextMenu/ContextMenuItem.cs
+++ b/UltraStar Play/Assets/Common/UI/ContextMenu/ContextMenuItem.cs
@@ -42,7 +42,6 @@ public class ContextMenuItem : MonoBehaviour
         {
             actionSubscriptionDisposable = button.OnClickAsObservable().Subscribe(_ =>
             {
-                Debug.Log("ContextMenuItem triggered");
                 action();
                 ContextMenu.CloseContextMenu();
             });

--- a/UltraStar Play/Assets/Common/UI/PlayerProfileUi/AvatarImage/AvatarImage.cs
+++ b/UltraStar Play/Assets/Common/UI/PlayerProfileUi/AvatarImage/AvatarImage.cs
@@ -17,24 +17,28 @@ public class AvatarImage : MonoBehaviour, INeedInjection, IExcludeFromSceneInjec
     [Inject(optional = true)]
     private MicProfile micProfile;
 
-    public void SetPlayerProfile(PlayerProfile playerProfile)
-    {
-        AvatarImageReference imageRef = FindObjectsOfType<AvatarImageReference>().Where(it => it.avatar == playerProfile.Avatar).FirstOrDefault();
-        if (imageRef != null)
-        {
-            image.sprite = imageRef.Sprite;
-        }
-        else
-        {
-            Debug.LogWarning("Did not find an image for the avatar: " + playerProfile.Avatar);
-        }
-    }
-
+    [Inject(optional = true)]
+    private PlayerProfile playerProfile;
+    
     public void OnInjectionFinished()
     {
         if (micProfile != null)
         {
             image.color = micProfile.Color;
+        }
+
+        if (playerProfile != null)
+        {
+            AvatarImageReference imageRef = FindObjectsOfType<AvatarImageReference>()
+                .FirstOrDefault(it => it.avatar == playerProfile.Avatar);
+            if (imageRef != null)
+            {
+                image.sprite = imageRef.Sprite;
+            }
+            else
+            {
+                Debug.LogWarning("Did not find an image for the avatar: " + playerProfile.Avatar);
+            }
         }
     }
 }

--- a/UltraStar Play/Assets/Scenes/Options/GameOptions/LanguageItemSlider.cs
+++ b/UltraStar Play/Assets/Scenes/Options/GameOptions/LanguageItemSlider.cs
@@ -7,16 +7,19 @@ using UniInject;
 
 public class LanguageItemSlider : TextItemSlider<SystemLanguage>, INeedInjection
 {
+    [Inject]
+    private I18NManager i18nManager;
+    
     protected override void Start()
     {
         base.Start();
-        Items = EnumUtils.GetValuesAsList<SystemLanguage>();
+        Items = i18nManager.GetTranslatedLanguages();
         SystemLanguage currentLanguage = SettingsManager.Instance.Settings.GameSettings.language;
-        Selection.Value = currentLanguage;
+        Selection.Value = Items.Contains(currentLanguage) ? currentLanguage : SystemLanguage.English;
         Selection.Subscribe(newValue =>
         {
             SettingsManager.Instance.Settings.GameSettings.language = newValue;
-            I18NManager.Instance.UpdateCurrentLanguageAndTranslations();
+            i18nManager.UpdateCurrentLanguageAndTranslations();
         });
     }
 

--- a/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerUiController/UiNotes/UiNote.cs
+++ b/UltraStar Play/Assets/Scenes/Sing/PlayerController/PlayerUiController/UiNotes/UiNote.cs
@@ -57,6 +57,7 @@ public class UiNote : MonoBehaviour
     void OnDestroy()
     {
         DestroyStars();
+        DestroyLyrics();
     }
 
     public void SetColorOfMicProfile(MicProfile micProfile)
@@ -100,6 +101,20 @@ public class UiNote : MonoBehaviour
         stars.Clear();
     }
 
+    private void DestroyLyrics()
+    {
+        if (lyricsUiText != null
+            && lyricsUiText.gameObject != null)
+        {
+            Destroy(lyricsUiText.gameObject);
+        }
+        if (lyricsUiTextRectTransform != null
+            && lyricsUiTextRectTransform.gameObject != null)
+        {
+            Destroy(lyricsUiTextRectTransform.gameObject);
+        }
+    }
+    
     private void CreateGoldenNoteEffect()
     {
         // Create several particles. Longer notes require more particles because they have more space to fill.

--- a/UltraStar Play/Assets/Scenes/Sing/SingSceneController.cs
+++ b/UltraStar Play/Assets/Scenes/Sing/SingSceneController.cs
@@ -393,7 +393,7 @@ public class SingSceneController : MonoBehaviour, INeedInjection, IBinder, IOnHo
             return Voice.soloVoiceName;
         }
 
-        List<string> voiceNames = new List<string>(SongMeta.VoiceNames.Values);
+        List<string> voiceNames = new List<string>(SongMeta.VoiceNames.Keys);
         int voiceNameCount = voiceNames.Count;
         if (voiceNameCount > 1)
         {

--- a/UltraStar Play/Assets/Scenes/Sing/SingSceneNoteDisplayer/ScrollingNoteStreamDisplayer.cs
+++ b/UltraStar Play/Assets/Scenes/Sing/SingSceneNoteDisplayer/ScrollingNoteStreamDisplayer.cs
@@ -115,7 +115,7 @@ public class ScrollingNoteStreamDisplayer : AbstractSingSceneNoteDisplayer
         lyricsRectTransform.anchorMax = new Vector2(lyricsRectTransform.anchorMax.x, 1);
         lyricsRectTransform.sizeDelta = new Vector2(lyricsRectTransform.sizeDelta.x, 0);
         lyricsRectTransform.localPosition = new Vector2(lyricsRectTransform.localPosition.x, 0);
-        uiNote.lyricsUiText.transform.SetParent(uiNote.RectTransform, true);
+        uiNote.lyricsUiText.transform.SetParent(lyricsBar, true);
     }
 
     private double GetNoteStartBeatOfFollowingNote(Note note)
@@ -152,7 +152,10 @@ public class ScrollingNoteStreamDisplayer : AbstractSingSceneNoteDisplayer
     {
         foreach (UiNote uiNote in noteToUiNoteMap.Values)
         {
+            Vector3 lastPosition = uiNote.RectTransform.position;
             PositionUiNote(uiNote.RectTransform, uiNote.Note.MidiNote, uiNote.Note.StartBeat, uiNote.Note.EndBeat);
+            Vector3 positionDelta = uiNote.RectTransform.position - lastPosition;
+            uiNote.lyricsUiTextRectTransform.Translate(positionDelta);
         }
 
         foreach (UiRecordedNote uiRecordedNote in uiRecordedNotes)

--- a/UltraStar Play/Assets/Scenes/SongEditor/Actions/DeleteNotesAction.cs
+++ b/UltraStar Play/Assets/Scenes/SongEditor/Actions/DeleteNotesAction.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using UniInject;
 
 // Disable warning about fields that are never assigned, their values are injected.
@@ -15,14 +16,27 @@ public class DeleteNotesAction : INeedInjection
     [Inject]
     private SongMetaChangeEventStream songMetaChangeEventStream;
 
+    [Inject]
+    private DeleteSentencesAction deleteSentencesAction;
+    
     public void Execute(IReadOnlyCollection<Note> selectedNotes)
     {
+        HashSet<Sentence> affectedSentences = new HashSet<Sentence>();
         foreach (Note note in selectedNotes)
         {
+            if (note.Sentence != null)
+            {
+                affectedSentences.Add(note.Sentence);
+            }
             note.SetSentence(null);
             songEditorLayerManager.RemoveNoteFromAllLayers(note);
             editorNoteDisplayer.DeleteNote(note);
         }
+
+        List<Sentence> affectedSentencesWithoutNotes = affectedSentences
+            .Where(sentence => sentence.Notes.Count == 0)
+            .ToList();
+        deleteSentencesAction.Execute(affectedSentencesWithoutNotes);
     }
 
     public void ExecuteAndNotify(IReadOnlyCollection<Note> selectedNotes)

--- a/UltraStar Play/Assets/Scenes/SongEditor/Actions/MoveNoteToOwnSentenceAction.cs
+++ b/UltraStar Play/Assets/Scenes/SongEditor/Actions/MoveNoteToOwnSentenceAction.cs
@@ -1,0 +1,52 @@
+using System.Collections.Generic;
+using System.Linq;
+using UniInject;
+
+// Disable warning about fields that are never assigned, their values are injected.
+#pragma warning disable CS0649
+
+public class MoveNoteToOwnSentenceAction : INeedInjection
+{
+    [Inject]
+    private SongMetaChangeEventStream songMetaChangeEventStream;
+    
+    [Inject]
+    private DeleteSentencesAction deleteSentencesAction;
+    
+    public bool CanMoveToOwnSentence(List<Note> notes)
+    {
+        if (notes.IsNullOrEmpty())
+        {
+            return false;
+        }
+        return notes.AnyMatch(note => note.Sentence?.Voice != null);
+    }
+
+    public void MoveToOwnSentence(List<Note> notes)
+    {
+        List<Sentence> affectedSentences = notes.Select(note => note.Sentence).ToList();
+
+        Sentence newSentence = new Sentence();
+        Voice voice = notes
+            .Select(note => note.Sentence?.Voice)
+            .FirstOrDefault();
+        newSentence.SetVoice(voice);
+        
+        notes.ForEach(note => note.SetSentence(newSentence));
+        newSentence.FitToNotes();
+        
+        // Remove old sentence if not more notes left
+        List<Sentence> sentencesWithoutNotes = affectedSentences.Where(it => it.Notes.IsNullOrEmpty()).ToList();
+        deleteSentencesAction.Execute(sentencesWithoutNotes);
+
+        // Fit sentences to notes
+        List<Sentence> sentencesWithNotes = affectedSentences.Where(it => !it.Notes.IsNullOrEmpty()).ToList();
+        sentencesWithNotes.ForEach(it => it.FitToNotes());
+    }
+
+    public void MoveToOwnSentenceAndNotify(List<Note> notes)
+    {
+        MoveToOwnSentence(notes);
+        songMetaChangeEventStream.OnNext(new SentencesChangedEvent());
+    }
+}

--- a/UltraStar Play/Assets/Scenes/SongEditor/Actions/MoveNoteToOwnSentenceAction.cs.meta
+++ b/UltraStar Play/Assets/Scenes/SongEditor/Actions/MoveNoteToOwnSentenceAction.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 02d746a1843a40ea939515c6130d16fb
+timeCreated: 1619966630

--- a/UltraStar Play/Assets/Scenes/SongEditor/Actions/MoveNotesToOtherVoiceAction.cs
+++ b/UltraStar Play/Assets/Scenes/SongEditor/Actions/MoveNotesToOtherVoiceAction.cs
@@ -21,6 +21,7 @@ public class MoveNotesToOtherVoiceAction : INeedInjection
     public void MoveNotesToVoice(SongMeta songMeta, List<Note> selectedNotes, string voiceName)
     {
         Voice voice = SongMetaUtils.GetOrCreateVoice(songMeta, voiceName);
+        Sentence createdSentence = null;
         List<Sentence> changedSentences = new List<Sentence>();
         foreach (Note note in selectedNotes)
         {
@@ -35,9 +36,14 @@ public class MoveNotesToOtherVoiceAction : INeedInjection
                 {
                     sentenceForNote = new Sentence(note.Sentence.MinBeat, note.Sentence.MaxBeat);
                 }
+                else if (createdSentence != null)
+                {
+                    sentenceForNote = createdSentence;
+                }
                 else
                 {
-                    sentenceForNote = new Sentence();
+                    createdSentence = new Sentence();
+                    sentenceForNote = createdSentence;
                 }
                 sentenceForNote.SetVoice(voice);
             }

--- a/UltraStar Play/Assets/Scenes/SongEditor/Actions/SongEditorActionBinder.cs
+++ b/UltraStar Play/Assets/Scenes/SongEditor/Actions/SongEditorActionBinder.cs
@@ -17,6 +17,7 @@ public class SongEditorActionBinder : MonoBehaviour, IBinder
         bb.BindTypeToNewInstances(typeof(AddNoteAction));
         bb.BindTypeToNewInstances(typeof(MoveNoteToAjacentSentenceAction));
         bb.BindTypeToNewInstances(typeof(MoveNotesToOtherVoiceAction));
+        bb.BindTypeToNewInstances(typeof(MoveNoteToOwnSentenceAction));
         bb.BindTypeToNewInstances(typeof(MoveNotesAction));
         bb.BindTypeToNewInstances(typeof(ExtendNotesAction));
 

--- a/UltraStar Play/Assets/Scenes/SongEditor/EditorNote/EditorNoteContextMenuHandler.cs
+++ b/UltraStar Play/Assets/Scenes/SongEditor/EditorNote/EditorNoteContextMenuHandler.cs
@@ -42,6 +42,9 @@ public class EditorNoteContextMenuHandler : AbstractContextMenuHandler
     private MoveNotesToOtherVoiceAction moveNotesToOtherVoiceAction;
 
     [Inject]
+    private MoveNoteToOwnSentenceAction moveNoteToOwnSentenceAction;
+
+    [Inject]
     private SpaceBetweenNotesAction spaceBetweenNotesAction;
 
     [Inject]
@@ -182,6 +185,11 @@ public class EditorNoteContextMenuHandler : AbstractContextMenuHandler
         {
             contextMenu.AddItem("Move to player 2",
                 () => moveNotesToOtherVoiceAction.MoveNotesToVoiceAndNotify(songMeta, selectedNotes, Voice.secondVoiceName));
+        }
+
+        if (moveNoteToOwnSentenceAction.CanMoveToOwnSentence(selectedNotes))
+        {
+            contextMenu.AddItem("Move to own sentence", () => moveNoteToOwnSentenceAction.MoveToOwnSentenceAndNotify(selectedNotes));
         }
     }
 

--- a/UltraStar Play/Assets/Scenes/SongEditor/EditorNote/EditorNoteDisplayer.cs
+++ b/UltraStar Play/Assets/Scenes/SongEditor/EditorNote/EditorNoteDisplayer.cs
@@ -78,7 +78,10 @@ public class EditorNoteDisplayer : MonoBehaviour, INeedInjection, ISceneInjectio
                 .Subscribe(_ => UpdateNotes());
         }
 
-        settings.SongEditorSettings.ObserveEveryValueChanged(it => it.HideVoices.Count).Subscribe(_ => OnHideVoicesChanged());
+        settings.SongEditorSettings
+            .ObserveEveryValueChanged(it => it.HideVoices.Count)
+            .Subscribe(_ => OnHideVoicesChanged())
+            .AddTo(this);
     }
 
     private void OnHideVoicesChanged()
@@ -182,7 +185,8 @@ public class EditorNoteDisplayer : MonoBehaviour, INeedInjection, ISceneInjectio
 
     public void UpdateNotes()
     {
-        if (!gameObject.activeInHierarchy)
+        if (gameObject == null 
+            || !gameObject.activeInHierarchy)
         {
             return;
         }

--- a/UltraStar Play/Assets/Scenes/SongEditor/EditorNote/EditorUiNote.cs
+++ b/UltraStar Play/Assets/Scenes/SongEditor/EditorNote/EditorUiNote.cs
@@ -109,6 +109,7 @@ public class EditorUiNote : MonoBehaviour,
             Color color = songEditorSceneController.GetColorForVoice(Note.Sentence.Voice);
             SetColor(color);
         }
+        UpdateFontSize();
     }
 
     void Start()

--- a/UltraStar Play/Assets/Scenes/SongEditor/EditorSentence/EditorUiSentencePrefab.prefab
+++ b/UltraStar Play/Assets/Scenes/SongEditor/EditorSentence/EditorUiSentencePrefab.prefab
@@ -60,11 +60,11 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: 21300000, guid: 55f3e2c7b25af03468f72991504fb124, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
@@ -139,11 +139,11 @@ MonoBehaviour:
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 0}
   m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_Sprite: {fileID: 0}
   m_Type: 0
   m_PreserveAspect: 0
@@ -167,6 +167,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   backgroundImage: {fileID: 300791945676296084}
+  uiText: {fileID: 0}
 --- !u!114 &3718104915973145978
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -238,12 +239,12 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
-  m_RaycastTarget: 1
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
-      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
   m_FontData:
     m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
     m_FontSize: 14

--- a/UltraStar Play/Assets/Scenes/SongEditor/OverviewBar/NoteOverviewVisualizer.cs
+++ b/UltraStar Play/Assets/Scenes/SongEditor/OverviewBar/NoteOverviewVisualizer.cs
@@ -77,6 +77,11 @@ public class NoteOverviewVisualizer : MonoBehaviour, INeedInjection, ISceneInjec
     private void DrawNotes(int songDurationInMillis, SongMeta songMeta, Voice voice, Color color)
     {
         List<Note> notes = voice.Sentences.SelectMany(sentence => sentence.Notes).ToList();
+        if (notes.IsNullOrEmpty())
+        {
+            return;
+        }
+        
         // constant offset to
         // (a) ensure that midiNoteRange > 0,
         // (b) have some space to the border of the texture.

--- a/UltraStar Play/Assets/Scenes/SongEditor/SongEditorNoteRecorder.cs
+++ b/UltraStar Play/Assets/Scenes/SongEditor/SongEditorNoteRecorder.cs
@@ -169,7 +169,7 @@ public class SongEditorNoteRecorder : MonoBehaviour, INeedInjection
 
     private void CreateNewRecordedNote(int midiNote, int currentBeat, ESongEditorLayer targetLayer)
     {
-        lastRecordedNote = new Note(ENoteType.Normal, currentBeat, 1, midiNote - 60, " ");
+        lastRecordedNote = new Note(ENoteType.Normal, currentBeat, 1, midiNote - 60, "");
         songEditorLayerManager.AddNoteToLayer(targetLayer, lastRecordedNote);
 
         // EndBeat of new note is currentBeat + 1. Overwrite notes that start before this beat.

--- a/UltraStar Play/Assets/Scenes/SongEditor/SongEditorSceneController.cs
+++ b/UltraStar Play/Assets/Scenes/SongEditor/SongEditorSceneController.cs
@@ -200,6 +200,18 @@ public class SongEditorSceneController : MonoBehaviour, IBinder, INeedInjection
         result.AddRange(notesInLayers);
         return result;
     }
+    
+    public List<Note> GetAllVisibleNotes()
+    {
+        List<Note> result = new List<Note>();
+        List<Note> notesInVoices = SongMetaUtils.GetAllNotes(SongMeta)
+            .Where(note => songEditorLayerManager.IsVisible(note))
+            .ToList();
+        List<Note> notesInLayers = songEditorLayerManager.GetAllNotes();
+        result.AddRange(notesInVoices);
+        result.AddRange(notesInLayers);
+        return result;
+    }
 
     private void CreateVoiceToColorMap()
     {

--- a/UltraStar Play/Assets/Scenes/SongEditor/SongEditorSceneInputControl.cs
+++ b/UltraStar Play/Assets/Scenes/SongEditor/SongEditorSceneInputControl.cs
@@ -336,13 +336,17 @@ public class SongEditorSceneInputControl : MonoBehaviour, INeedInjection
             && (Keyboard.current.leftArrowKey.isPressed || Keyboard.current.rightArrowKey.isPressed)
             && selectionController.GetSelectedNotes().IsNullOrEmpty())
         {
+            int stepInMillis = InputUtils.IsKeyboardShiftPressed()
+                ? 1
+                : 10;
+            
             if (Keyboard.current.leftArrowKey.isPressed)
             {
-                songAudioPlayer.PositionInSongInMillis -= 1;
+                songAudioPlayer.PositionInSongInMillis -= stepInMillis;
             }
             else if (Keyboard.current.rightArrowKey.isPressed)
             {
-                songAudioPlayer.PositionInSongInMillis += 1;
+                songAudioPlayer.PositionInSongInMillis += stepInMillis;
             }
         }
         

--- a/UltraStar Play/Assets/Scenes/SongEditor/SongEditorSelectionController.cs
+++ b/UltraStar Play/Assets/Scenes/SongEditor/SongEditorSelectionController.cs
@@ -27,6 +27,9 @@ public class SongEditorSelectionController : MonoBehaviour, INeedInjection
     [Inject]
     private SongMeta songMeta;
 
+    [Inject]
+    private SongEditorLayerManager layerManager;
+    
     private readonly NoteHashSet selectedNotes = new NoteHashSet();
 
     public List<Note> GetSelectedNotes()
@@ -57,7 +60,7 @@ public class SongEditorSelectionController : MonoBehaviour, INeedInjection
 
     public void SelectAll()
     {
-        List<Note> allNotes = songEditorSceneController.GetAllNotes();
+        List<Note> allNotes = songEditorSceneController.GetAllVisibleNotes();
         SetSelection(allNotes);
     }
 
@@ -91,6 +94,10 @@ public class SongEditorSelectionController : MonoBehaviour, INeedInjection
         ClearSelection();
         foreach (Note note in notes)
         {
+            if (!layerManager.IsVisible(note))
+            {
+                continue;
+            }
             selectedNotes.Add(note);
 
             EditorUiNote uiNote = editorNoteDisplayer.GetUiNoteForNote(note);
@@ -141,7 +148,7 @@ public class SongEditorSelectionController : MonoBehaviour, INeedInjection
             return;
         }
 
-        List<Note> notes = songEditorSceneController.GetAllNotes();
+        List<Note> notes = songEditorSceneController.GetAllVisibleNotes();
         int maxEndBeat = selectedNotes.Select(it => it.EndBeat).Max();
 
         // Find the next note, i.e., the note right of maxEndBeat with the smallest distance to it.
@@ -180,7 +187,7 @@ public class SongEditorSelectionController : MonoBehaviour, INeedInjection
             return;
         }
 
-        List<Note> notes = songEditorSceneController.GetAllNotes();
+        List<Note> notes = songEditorSceneController.GetAllVisibleNotes();
         int minStartBeat = selectedNotes.Select(it => it.StartBeat).Min();
 
         // Find the previous note, i.e., the note left of minStartBeat with the smallest distance to it.

--- a/UltraStar Play/Assets/Scenes/SongEditor/SongEditorSelectionController.cs
+++ b/UltraStar Play/Assets/Scenes/SongEditor/SongEditorSelectionController.cs
@@ -34,6 +34,12 @@ public class SongEditorSelectionController : MonoBehaviour, INeedInjection
         return new List<Note>(selectedNotes);
     }
 
+    public bool HasSelectedNotes()
+    {
+        return selectedNotes != null
+               && selectedNotes.Count > 0;
+    }
+    
     public bool IsSelected(Note note)
     {
         return selectedNotes.Contains(note);

--- a/UltraStar Play/Assets/Scenes/SongSelect/SongSelectSceneInputControl.cs
+++ b/UltraStar Play/Assets/Scenes/SongSelect/SongSelectSceneInputControl.cs
@@ -108,13 +108,11 @@ public class SongSelectSceneInputControl : MonoBehaviour, INeedInjection
 
     private void OnNavigate(InputAction.CallbackContext context)
     {   
-        if (context.ReadValue<Vector2>().x > 0
-            && !songSelectSceneController.IsSearchEnabled()) 
+        if (context.ReadValue<Vector2>().x > 0) 
         {
             songRouletteController.SelectNextSong();
         }
-        if (context.ReadValue<Vector2>().x < 0
-            && !songSelectSceneController.IsSearchEnabled())
+        if (context.ReadValue<Vector2>().x < 0)
         {
             songRouletteController.SelectPreviousSong();
         }

--- a/UltraStar Play/Assets/VERSION.txt
+++ b/UltraStar Play/Assets/VERSION.txt
@@ -1,4 +1,4 @@
-release = 0.3
-build_timestamp = 2104081801
-commit_hash = 5e07588
+release = 0.3.1
+build_timestamp = 2105021747
+commit_hash = f8d1102
 website_link = https://usplay.net/

--- a/UltraStar Play/ProjectSettings/ProjectSettings.asset
+++ b/UltraStar Play/ProjectSettings/ProjectSettings.asset
@@ -127,7 +127,7 @@ PlayerSettings:
     16:10: 1
     16:9: 1
     Others: 1
-  bundleVersion: 0.3
+  bundleVersion: 0.3.1
   preloadedAssets:
   - {fileID: 11400000, guid: 14252c98bd239904da98289cb5928ea0, type: 2}
   metroInputSource: 0


### PR DESCRIPTION
### What does this PR do?

A minor PR that fixes tons of small issues:

- only show available languages in language slider
    - No need to show languages that fall back to English anyway
- Player profile image was not correctly shown in sing-scene and singing-results-scene
    - was always the default image
- lyrics when using ScrollingNoteStream were *behind* their background
    - This made the lyrics more difficult to read instead of easier to read
- some duet songs were not working. Was using wrong "voice name"
    - in song files, it is possible to provide names for `#P1` and `#P2`. When these were present, it crashed
- cannot select next/previous song when searching
    - no idea why I added this condition

Also fixes tons of issues with the song-editor:
- context menu of sentence in song-editor not working
    - the Text component was in front of the raycast target, blocking the context menu
- sentence should be removed when all its notes are removed
- faster changing playback position in increments (hold Ctrl and right/left arrow)
    - 1ms is nothing. I increased it to 10ms.
- assigning new notes to voice was choosing the wrong voice
- "Move notes to player" and "paste notes" should create a single sentence for the notes (instead of one sentence per note)
- new "move to own sentence" action
- wrong font size on notes sometimes
- fix NPE
- dont add space as lyrics to newly created note when recording notes

Fixed conflicting controls in song-editor:
- "space" in TextArea should not start/stop playback
- "delete" or "select all" in TextArea should not affect selected notes
- "escape" in TextArea should remove focus from TextArea, not exit the scene
- "escape" with content-to-be-pasted should cancel content-to-be-pasted, not exit the scene
- "escape" with selected notes should deselect notes, not exit the scene

Will create a new 0.3.1 release when this has been merged