### PR TITLE
build macOS to check if  compilation works using unity-test-runner

### DIFF
--- a/.github/workflows/test-unity-project.yml
+++ b/.github/workflows/test-unity-project.yml
@@ -24,6 +24,7 @@ jobs:
         targetPlatform:
           # At the moment, tests are target platform independent. Thus only build one.
           - StandaloneLinux64
+          - StandaloneOSX
     steps:
       # Clone repo and restore cache
       - uses: actions/checkout@v2


### PR DESCRIPTION
### What does this PR do?

For some reason the macOS executable build does not work with unity-builder GitHub Action.
This PR is to check, if the compilation also fails with the unity-test-runner.

Please, don't merge this PR.
