### PR TITLE
Anst/stream media

### DIFF
--- a/UltraStar Play/Assets/Common/Audio/AudioManager.cs
+++ b/UltraStar Play/Assets/Common/Audio/AudioManager.cs
@@ -106,10 +106,9 @@ public class AudioManager : MonoBehaviour
 
     private AudioClip LoadAndCacheAudioClip(string uri, bool streamAudio)
     {
-        if (!WebRequestUtils.IsHttpOrHttpsUri(uri)
-            && !File.Exists(uri.Replace("file://", "")))
+        if (!WebRequestUtils.ResourceExists(uri))
         {
-            Debug.LogError("File does not exist: " + uri);
+            Debug.LogError("Audio file resource does not exist: " + uri);
             return null;
         }
 

--- a/UltraStar Play/Assets/Common/Audio/AudioManager.cs
+++ b/UltraStar Play/Assets/Common/Audio/AudioManager.cs
@@ -51,11 +51,11 @@ public class AudioManager : MonoBehaviour
 
     public AudioClip LoadAudioClipFromFile(string path, bool streamAudio = true)
     {
-        return LoadAudioClip("file://" + path, streamAudio);
+        return LoadAudioClipFromUri("file://" + path, streamAudio);
     }
 
     // When streamAudio is false, all audio data is loaded at once in a blocking way.
-    public AudioClip LoadAudioClip(string uri, bool streamAudio = true)
+    public AudioClip LoadAudioClipFromUri(string uri, bool streamAudio = true)
     {
         if (audioClipCache.TryGetValue(uri, out CachedAudioClip cachedAudioClip)
             && (cachedAudioClip.StreamedAudioClip != null || cachedAudioClip.FullAudioClip))
@@ -71,28 +71,6 @@ public class AudioManager : MonoBehaviour
         }
 
         return LoadAndCacheAudioClip(uri, streamAudio);
-    }
-
-    public void LoadAudioClipFromUri(string uri, Action<AudioClip> onSuccess, Action<UnityWebRequest> onFailure = null)
-    {
-        if (audioClipCache.TryGetValue(uri, out CachedAudioClip cachedAudioClip)
-            && (cachedAudioClip.StreamedAudioClip != null || cachedAudioClip.FullAudioClip))
-        {
-            onSuccess(cachedAudioClip.FullAudioClip);
-            return;
-        }
-
-        Action<AudioClip> doCacheAudioClipThenOnSuccess = (loadedAudioClip) =>
-        {
-            AddAudioClipToCache(uri, loadedAudioClip, true);
-            onSuccess(loadedAudioClip);
-        };
-
-        if (coroutineManager == null)
-        {
-            coroutineManager = CoroutineManager.Instance;
-        }
-        coroutineManager.StartCoroutine(WebRequestUtils.LoadAudioClipFromUri(uri, doCacheAudioClipThenOnSuccess, onFailure));
     }
 
     public static void ClearCache()

--- a/UltraStar Play/Assets/Common/Audio/AudioUtils.cs
+++ b/UltraStar Play/Assets/Common/Audio/AudioUtils.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.Networking;
@@ -9,29 +10,35 @@ public static class AudioUtils
 {
     // This method should only be called from tests and the AudioManager.
     // Use the cached version of the AudioManager for the normal game logic.
-    public static AudioClip GetAudioClipUncached(string path, bool streamAudio)
+    public static AudioClip GetAudioClipUncached(string uri, bool streamAudio)
     {
-        if (!System.IO.File.Exists(path))
+        if (!WebRequestUtils.IsHttpOrHttpsUri(uri)
+            && !File.Exists(uri))
         {
-            Debug.LogWarning($"Can not open audio file because it does not exist: {path}");
+            Debug.LogWarning($"Can not open audio file because it does not exist: {uri}");
             return null;
         }
-        string fileExtension = System.IO.Path.GetExtension(path);
 
+        string fileExtension = Path.GetExtension(uri);
         if (fileExtension.ToLowerInvariant().Equals(".mp3"))
         {
-            AudioClip audioClip = LoadMp3(path);
+            if (WebRequestUtils.IsHttpOrHttpsUri(uri))
+            {
+                throw new ArgumentException("Streaming of MP3 audio is not supported. Please use OGG audio instead.");
+            }
+
+            AudioClip audioClip = LoadMp3(uri);
             return audioClip;
         }
         else
         {
-            return LoadAudio(path, streamAudio);
+            return LoadAudio(uri, streamAudio);
         }
     }
 
-    private static AudioClip LoadAudio(string path, bool streamAudio)
+    private static AudioClip LoadAudio(string uri, bool streamAudio)
     {
-        using (UnityWebRequest webRequest = UnityWebRequestMultimedia.GetAudioClip("file://" + path, AudioType.UNKNOWN))
+        using (UnityWebRequest webRequest = UnityWebRequestMultimedia.GetAudioClip(uri, AudioType.UNKNOWN))
         {
             DownloadHandlerAudioClip downloadHandler = webRequest.downloadHandler as DownloadHandlerAudioClip;
             downloadHandler.streamAudio = streamAudio;
@@ -39,7 +46,7 @@ public static class AudioUtils
             webRequest.SendWebRequest();
             if (webRequest.isNetworkError || webRequest.isHttpError)
             {
-                Debug.LogError("Error Loading Audio: " + path);
+                Debug.LogError("Error Loading Audio: " + uri);
                 Debug.LogError(webRequest.error);
                 return null;
             }
@@ -54,7 +61,7 @@ public static class AudioUtils
 
     public static AudioClip LoadMp3(string path)
     {
-        string filename = System.IO.Path.GetFileNameWithoutExtension(path);
+        string filename = Path.GetFileNameWithoutExtension(path);
         MpegFile mpegFile = new MpegFile(path);
         if (mpegFile == null || mpegFile.Length < 1)
         {

--- a/UltraStar Play/Assets/Common/Audio/AudioUtils.cs
+++ b/UltraStar Play/Assets/Common/Audio/AudioUtils.cs
@@ -26,7 +26,8 @@ public static class AudioUtils
                 throw new ArgumentException("Streaming of MP3 audio is not supported. Please use OGG audio instead.");
             }
 
-            AudioClip audioClip = LoadMp3(uri);
+            string filePath = uri.Replace("file://", "");
+            AudioClip audioClip = LoadMp3(filePath);
             return audioClip;
         }
         else

--- a/UltraStar Play/Assets/Common/Audio/AudioUtils.cs
+++ b/UltraStar Play/Assets/Common/Audio/AudioUtils.cs
@@ -12,10 +12,9 @@ public static class AudioUtils
     // Use the cached version of the AudioManager for the normal game logic.
     public static AudioClip GetAudioClipUncached(string uri, bool streamAudio)
     {
-        if (!WebRequestUtils.IsHttpOrHttpsUri(uri)
-            && !File.Exists(uri))
+        if (!WebRequestUtils.ResourceExists(uri))
         {
-            Debug.LogWarning($"Can not open audio file because it does not exist: {uri}");
+            Debug.LogWarning($"Audio file resource does not exist: {uri}");
             return null;
         }
 

--- a/UltraStar Play/Assets/Common/Audio/SongAudioPlayer/SongAudioPlayer.cs
+++ b/UltraStar Play/Assets/Common/Audio/SongAudioPlayer/SongAudioPlayer.cs
@@ -19,31 +19,16 @@ public class SongAudioPlayer : MonoBehaviour
     private int positionInSongInMillisFrame;
 
     private readonly Subject<double> playbackStoppedEventStream = new Subject<double>();
-    public ISubject<double> PlaybackStoppedEventStream
-    {
-        get
-        {
-            return playbackStoppedEventStream;
-        }
-    }
+    public IObservable<double> PlaybackStoppedEventStream => playbackStartedEventStream;
 
     private readonly Subject<double> playbackStartedEventStream = new Subject<double>();
-    public ISubject<double> PlaybackStartedEventStream
-    {
-        get
-        {
-            return playbackStartedEventStream;
-        }
-    }
+    public IObservable<double> PlaybackStartedEventStream => playbackStartedEventStream;
 
     private readonly Subject<double> positionInSongEventStream = new Subject<double>();
-    public ISubject<double> PositionInSongEventStream
-    {
-        get
-        {
-            return positionInSongEventStream;
-        }
-    }
+    public IObservable<double> PositionInSongEventStream => positionInSongEventStream;
+
+    private readonly Subject<AudioClip> audioClipLoadedEventStream = new Subject<AudioClip>();
+    public IObservable<AudioClip> AudioClipLoadedEventStream => audioClipLoadedEventStream;
 
     public IObservable<Pair<double>> JumpBackInSongEventStream
     {
@@ -228,6 +213,7 @@ public class SongAudioPlayer : MonoBehaviour
         {
             audioPlayer.clip = audioClip;
             DurationOfSongInMillis = 1000.0 * audioClip.samples / audioClip.frequency;
+            audioClipLoadedEventStream.OnNext(audioClip);
         }
         else
         {

--- a/UltraStar Play/Assets/Common/Audio/SongAudioPlayer/SongAudioPlayer.cs
+++ b/UltraStar Play/Assets/Common/Audio/SongAudioPlayer/SongAudioPlayer.cs
@@ -218,8 +218,8 @@ public class SongAudioPlayer : MonoBehaviour
     {
         this.SongMeta = songMeta;
 
-        string songPath = SongMetaUtils.GetAbsoluteSongAudioPath(songMeta);
-        AudioClip audioClip = AudioManager.Instance.LoadAudioClip(songPath);
+        string audioUri = SongMetaUtils.GetAudioUri(songMeta);
+        AudioClip audioClip = AudioManager.Instance.LoadAudioClip(audioUri);
         if (audioClip != null)
         {
             audioPlayer.clip = audioClip;

--- a/UltraStar Play/Assets/Common/Audio/SongAudioPlayer/SongAudioPlayer.cs
+++ b/UltraStar Play/Assets/Common/Audio/SongAudioPlayer/SongAudioPlayer.cs
@@ -206,7 +206,7 @@ public class SongAudioPlayer : MonoBehaviour
         }
     }
 
-    void Update()
+    private void Update()
     {
         if (IsPlaying)
         {
@@ -216,10 +216,14 @@ public class SongAudioPlayer : MonoBehaviour
 
     public void Init(SongMeta songMeta)
     {
-        this.SongMeta = songMeta;
+        if (!gameObject.activeInHierarchy)
+        {
+            return;
+        }
 
+        this.SongMeta = songMeta;
         string audioUri = SongMetaUtils.GetAudioUri(songMeta);
-        AudioClip audioClip = AudioManager.Instance.LoadAudioClip(audioUri);
+        AudioClip audioClip = AudioManager.Instance.LoadAudioClipFromUri(audioUri);
         if (audioClip != null)
         {
             audioPlayer.clip = audioClip;

--- a/UltraStar Play/Assets/Common/Graphics/ImageManager.cs
+++ b/UltraStar Play/Assets/Common/Graphics/ImageManager.cs
@@ -22,34 +22,9 @@ public static class ImageManager
 
     private static CoroutineManager coroutineManager;
 
-    public static Sprite LoadSpriteFromFile(string path)
+    public static void LoadSpriteFromFile(string path, Action<Sprite> onSuccess, Action<UnityWebRequest> onFailure = null)
     {
-        return LoadSprite("file://" + path);
-    }
-
-    public static Sprite LoadSprite(string path)
-    {
-        if (spriteCache.TryGetValue(path, out CachedSprite cachedSprite)
-            && cachedSprite.Sprite != null)
-        {
-            return cachedSprite.Sprite;
-        }
-
-        if (!File.Exists(path))
-        {
-            Debug.LogError("File does not exist: " + path);
-            return null;
-        }
-
-        Sprite sprite = CreateNewSpriteUncached(path);
-        if (sprite == null)
-        {
-            Debug.LogError("Could not create sprite from path: " + path);
-            return null;
-        }
-
-        AddSpriteToCache(sprite, path);
-        return sprite;
+        LoadSpriteFromUri("file://" + path, onSuccess, onFailure);
     }
 
     public static void LoadSpriteFromUri(string uri, Action<Sprite> onSuccess, Action<UnityWebRequest> onFailure = null)
@@ -58,6 +33,12 @@ public static class ImageManager
             && cachedSprite.Sprite != null)
         {
             onSuccess(cachedSprite.Sprite);
+            return;
+        }
+
+        if (!WebRequestUtils.ResourceExists(uri))
+        {
+            Debug.LogError("Image resource does not exist: " + uri);
             return;
         }
 
@@ -73,24 +54,6 @@ public static class ImageManager
             coroutineManager = CoroutineManager.Instance;
         }
         coroutineManager.StartCoroutineAlsoForEditor(WebRequestUtils.LoadTexture2DFromUri(uri, DoCacheSpriteThenOnSuccess, onFailure));
-    }
-
-    public static Texture2D LoadTextureUncached(string path)
-    {
-        int width = 256;
-        int height = 256;
-        byte[] bytes = File.ReadAllBytes(path);
-        Texture2D texture = new Texture2D(width, height, TextureFormat.RGB24, false);
-        texture.filterMode = FilterMode.Trilinear;
-        texture.LoadImage(bytes);
-        return texture;
-    }
-
-    private static Sprite CreateNewSpriteUncached(string path)
-    {
-        Texture2D texture = LoadTextureUncached(path);
-        Sprite sprite = Sprite.Create(texture, new Rect(0, 0, texture.width, texture.height), new Vector2(0.5f, 0.5f), 1.0f);
-        return sprite;
     }
 
     private static void AddSpriteToCache(Sprite sprite, string source)

--- a/UltraStar Play/Assets/Common/Graphics/ImageManager.cs
+++ b/UltraStar Play/Assets/Common/Graphics/ImageManager.cs
@@ -22,6 +22,11 @@ public static class ImageManager
 
     private static CoroutineManager coroutineManager;
 
+    public static Sprite LoadSpriteFromFile(string path)
+    {
+        return LoadSprite("file://" + path);
+    }
+
     public static Sprite LoadSprite(string path)
     {
         if (spriteCache.TryGetValue(path, out CachedSprite cachedSprite)

--- a/UltraStar Play/Assets/Common/Model/Song/SongMetaUtils.cs
+++ b/UltraStar Play/Assets/Common/Model/Song/SongMetaUtils.cs
@@ -2,38 +2,44 @@
 using System.IO;
 using System.Linq;
 using System.Text;
+using ProTrans;
 using UnityEngine;
 
 public static class SongMetaUtils
 {
-    public static string GetAbsoluteSongVideoPath(SongMeta songMeta)
+    public static string GetCoverUri(SongMeta songMeta)
     {
-        if (songMeta.Video.IsNullOrEmpty())
-        {
-            return "";
-        }
-
-        if (WebRequestUtils.IsHttpOrHttpsUri(songMeta.Video))
-        {
-            return songMeta.Video;
-        }
-
-        return songMeta.Directory + Path.DirectorySeparatorChar + songMeta.Video;
+        return GetUri(songMeta, songMeta.Cover);
     }
 
-    public static string GetAbsoluteSongAudioPath(SongMeta songMeta)
+    public static string GetBackgroundUri(SongMeta songMeta)
     {
-        if (songMeta.Mp3.IsNullOrEmpty())
+        return GetUri(songMeta, songMeta.Background);
+    }
+
+    public static string GetVideoUri(SongMeta songMeta)
+    {
+        return GetUri(songMeta, songMeta.Video);
+    }
+
+    public static string GetAudioUri(SongMeta songMeta)
+    {
+        return GetUri(songMeta, songMeta.Mp3);
+    }
+
+    private static string GetUri(SongMeta songMeta, string pathOrUri)
+    {
+        if (pathOrUri.IsNullOrEmpty())
         {
             return "";
         }
 
-        if (WebRequestUtils.IsHttpOrHttpsUri(songMeta.Mp3))
+        if (WebRequestUtils.IsHttpOrHttpsUri(pathOrUri))
         {
-            return songMeta.Mp3;
+            return pathOrUri;
         }
 
-        return songMeta.Directory + Path.DirectorySeparatorChar + songMeta.Mp3;
+        return "file://" + songMeta.Directory + Path.DirectorySeparatorChar + pathOrUri;
     }
 
     public static string GetAbsoluteSongMetaPath(SongMeta songMeta)

--- a/UltraStar Play/Assets/Common/Model/Song/SongMetaUtils.cs
+++ b/UltraStar Play/Assets/Common/Model/Song/SongMetaUtils.cs
@@ -13,11 +13,26 @@ public static class SongMetaUtils
             return "";
         }
 
+        if (WebRequestUtils.IsHttpOrHttpsUri(songMeta.Video))
+        {
+            return songMeta.Video;
+        }
+
         return songMeta.Directory + Path.DirectorySeparatorChar + songMeta.Video;
     }
 
     public static string GetAbsoluteSongAudioPath(SongMeta songMeta)
     {
+        if (songMeta.Mp3.IsNullOrEmpty())
+        {
+            return "";
+        }
+
+        if (WebRequestUtils.IsHttpOrHttpsUri(songMeta.Mp3))
+        {
+            return songMeta.Mp3;
+        }
+
         return songMeta.Directory + Path.DirectorySeparatorChar + songMeta.Mp3;
     }
 
@@ -39,8 +54,8 @@ public static class SongMetaUtils
 
     public static Sentence FindExistingSentenceForNote(IReadOnlyCollection<Sentence> sentences, Note note)
     {
-        return sentences.Where(sentence => (sentence.MinBeat <= note.StartBeat)
-                                        && (note.EndBeat <= sentence.ExtendedMaxBeat)).FirstOrDefault();
+        return sentences.FirstOrDefault(sentence => (sentence.MinBeat <= note.StartBeat)
+                                                    && (note.EndBeat <= sentence.ExtendedMaxBeat));
     }
 
     public static Voice GetOrCreateVoice(SongMeta songMeta, string voiceName)

--- a/UltraStar Play/Assets/Common/Model/SongMetaManager.cs
+++ b/UltraStar Play/Assets/Common/Model/SongMetaManager.cs
@@ -197,7 +197,8 @@ public class SongMetaManager : MonoBehaviour, INeedInjection
             Debug.LogWarning("Unsupported audio format: " + songMeta.Mp3);
             return false;
         }
-        else if (!File.Exists(SongMetaUtils.GetAbsoluteSongAudioPath(songMeta)))
+        else if (!WebRequestUtils.IsHttpOrHttpsUri(songMeta.Mp3)
+                 && !File.Exists(SongMetaUtils.GetAbsoluteSongAudioPath(songMeta)))
         {
             Debug.LogWarning("Audio file does not exist: " + SongMetaUtils.GetAbsoluteSongAudioPath(songMeta));
             return false;

--- a/UltraStar Play/Assets/Common/Model/SongMetaManager.cs
+++ b/UltraStar Play/Assets/Common/Model/SongMetaManager.cs
@@ -182,10 +182,9 @@ public class SongMetaManager : MonoBehaviour, INeedInjection
                 Debug.LogWarning("Unsupported video format: " + songMeta.Video);
                 songMeta.Video = "";
             }
-            else if (!WebRequestUtils.IsHttpOrHttpsUri(songMeta.Video)
-                     && !File.Exists(SongMetaUtils.GetAbsoluteSongVideoPath(songMeta)))
+            else if (!WebRequestUtils.ResourceExists(SongMetaUtils.GetVideoUri(songMeta)))
             {
-                Debug.LogWarning("Video file does not exist: " + SongMetaUtils.GetAbsoluteSongVideoPath(songMeta));
+                Debug.LogWarning("Video file resource does not exist: " + SongMetaUtils.GetVideoUri(songMeta));
                 songMeta.Video = "";
             }
         }
@@ -197,10 +196,9 @@ public class SongMetaManager : MonoBehaviour, INeedInjection
             Debug.LogWarning("Unsupported audio format: " + songMeta.Mp3);
             return false;
         }
-        else if (!WebRequestUtils.IsHttpOrHttpsUri(songMeta.Mp3)
-                 && !File.Exists(SongMetaUtils.GetAbsoluteSongAudioPath(songMeta)))
+        else if (!WebRequestUtils.ResourceExists(SongMetaUtils.GetAudioUri(songMeta)))
         {
-            Debug.LogWarning("Audio file does not exist: " + SongMetaUtils.GetAbsoluteSongAudioPath(songMeta));
+            Debug.LogWarning("Audio file resource does not exist: " + SongMetaUtils.GetAudioUri(songMeta));
             return false;
         }
 

--- a/UltraStar Play/Assets/Common/Model/SongMetaManager.cs
+++ b/UltraStar Play/Assets/Common/Model/SongMetaManager.cs
@@ -182,7 +182,8 @@ public class SongMetaManager : MonoBehaviour, INeedInjection
                 Debug.LogWarning("Unsupported video format: " + songMeta.Video);
                 songMeta.Video = "";
             }
-            else if (!File.Exists(SongMetaUtils.GetAbsoluteSongVideoPath(songMeta)))
+            else if (!WebRequestUtils.IsHttpOrHttpsUri(songMeta.Video)
+                     && !File.Exists(SongMetaUtils.GetAbsoluteSongVideoPath(songMeta)))
             {
                 Debug.LogWarning("Video file does not exist: " + SongMetaUtils.GetAbsoluteSongVideoPath(songMeta));
                 songMeta.Video = "";

--- a/UltraStar Play/Assets/Common/Theme/Theme.cs
+++ b/UltraStar Play/Assets/Common/Theme/Theme.cs
@@ -38,7 +38,7 @@ public class Theme
         AudioClip audioClip = null;
         if (File.Exists(fullAudioPath))
         {
-            audioClip = audioManager.LoadAudioClip(fullAudioPath);
+            audioClip = audioManager.LoadAudioClipFromFile(fullAudioPath);
         }
         else if (ParentTheme != null)
         {
@@ -57,7 +57,7 @@ public class Theme
         Sprite sprite = null;
         if (File.Exists(fullImagePath))
         {
-            sprite = ImageManager.LoadSprite(fullImagePath);
+            sprite = ImageManager.LoadSpriteFromFile(fullImagePath);
         }
         else if (ParentTheme != null)
         {

--- a/UltraStar Play/Assets/Common/Theme/Theme.cs
+++ b/UltraStar Play/Assets/Common/Theme/Theme.cs
@@ -57,7 +57,6 @@ public class Theme
         Sprite sprite = null;
         if (File.Exists(fullImagePath))
         {
-            // sprite = ImageManager.LoadSpriteFromFile(fullImagePath);
             return null;
         }
         else if (ParentTheme != null)

--- a/UltraStar Play/Assets/Common/Theme/Theme.cs
+++ b/UltraStar Play/Assets/Common/Theme/Theme.cs
@@ -57,7 +57,8 @@ public class Theme
         Sprite sprite = null;
         if (File.Exists(fullImagePath))
         {
-            sprite = ImageManager.LoadSpriteFromFile(fullImagePath);
+            // sprite = ImageManager.LoadSpriteFromFile(fullImagePath);
+            return null;
         }
         else if (ParentTheme != null)
         {

--- a/UltraStar Play/Assets/Common/Util/WebRequestUtils.cs
+++ b/UltraStar Play/Assets/Common/Util/WebRequestUtils.cs
@@ -119,4 +119,16 @@ public static class WebRequestUtils
         return uri.StartsWith("http://")
                || uri.StartsWith("https://");
     }
+
+    public static bool ResourceExists(string uri)
+    {
+        if (uri.StartsWith("file://")
+            && !File.Exists(uri.Replace("file://", "")))
+        {
+            return false;
+        }
+
+        // Assume that the resource exists.
+        return true;
+    }
 }

--- a/UltraStar Play/Assets/Common/Util/WebRequestUtils.cs
+++ b/UltraStar Play/Assets/Common/Util/WebRequestUtils.cs
@@ -113,4 +113,10 @@ public static class WebRequestUtils
             onSuccess(webRequest.downloadHandler.text);
         }
     }
+
+    public static bool IsHttpOrHttpsUri(string uri)
+    {
+        return uri.StartsWith("http://")
+               || uri.StartsWith("https://");
+    }
 }

--- a/UltraStar Play/Assets/Common/Util/WebRequestUtils.cs
+++ b/UltraStar Play/Assets/Common/Util/WebRequestUtils.cs
@@ -37,83 +37,6 @@ public static class WebRequestUtils
         }
     }
 
-    // Do not use this method directly!
-    // Instead, use the AudioManager where AudioClips are cached and released when no longer needed.
-    public static IEnumerator LoadAudioClipFromUri(string uri, Action<AudioClip> onSuccess, Action<UnityWebRequest> onFailure = null)
-    {
-        using (UnityWebRequest webRequest = UnityWebRequestMultimedia.GetAudioClip(uri, AudioType.UNKNOWN))
-        {
-            DownloadHandlerAudioClip downloadHandler = webRequest.downloadHandler as DownloadHandlerAudioClip;
-            downloadHandler.streamAudio = true;
-            webRequest.SendWebRequest();
-
-            while (!webRequest.isDone)
-            {
-                yield return null;
-            }
-
-            if (webRequest.isNetworkError || webRequest.isHttpError)
-            {
-                if (onFailure != null)
-                {
-                    onFailure(webRequest);
-                    yield break;
-                }
-
-                Debug.LogError("Error loading AudioClip from: " + uri);
-                Debug.LogError(webRequest.error);
-                yield break;
-            }
-
-            onSuccess(downloadHandler.audioClip);
-        }
-    }
-
-    public static void LoadTextFromUri(CoroutineManager coroutineManager, string uri, Action<string> onSuccess, Action<UnityWebRequest> onFailure = null)
-    {
-        // Immediately load file if possible
-        if (uri.StartsWith("file://"))
-        {
-            string path = uri.Substring(7);
-            if (File.Exists(path))
-            {
-                string content = File.ReadAllText(path);
-                onSuccess(content);
-                return;
-            }
-        }
-
-        coroutineManager.StartCoroutineAlsoForEditor(WebRequestUtils.LoadTextFromUriCoroutine(uri, onSuccess, onFailure));
-    }
-
-    private static IEnumerator LoadTextFromUriCoroutine(string uri, Action<string> onSuccess, Action<UnityWebRequest> onFailure = null)
-    {
-        using (UnityWebRequest webRequest = UnityWebRequest.Get(uri))
-        {
-            webRequest.SendWebRequest();
-
-            while (!webRequest.isDone)
-            {
-                yield return null;
-            }
-
-            if (webRequest.isNetworkError || webRequest.isHttpError)
-            {
-                if (onFailure != null)
-                {
-                    onFailure(webRequest);
-                    yield break;
-                }
-
-                Debug.LogError("Error loading text from: " + uri);
-                Debug.LogError(webRequest.error);
-                yield break;
-            }
-
-            onSuccess(webRequest.downloadHandler.text);
-        }
-    }
-
     public static bool IsHttpOrHttpsUri(string uri)
     {
         return uri.StartsWith("http://")
@@ -122,13 +45,13 @@ public static class WebRequestUtils
 
     public static bool ResourceExists(string uri)
     {
-        if (uri.StartsWith("file://")
+        if (!uri.IsNullOrEmpty()
+            && uri.StartsWith("file://")
             && !File.Exists(uri.Replace("file://", "")))
         {
             return false;
         }
 
-        // Assume that the resource exists.
-        return true;
+        return !uri.IsNullOrEmpty();
     }
 }

--- a/UltraStar Play/Assets/Common/Video/SongVideoPlayer/SongVideoPlayer.cs
+++ b/UltraStar Play/Assets/Common/Video/SongVideoPlayer/SongVideoPlayer.cs
@@ -82,7 +82,7 @@ public class SongVideoPlayer : MonoBehaviour, INeedInjection, IInjectionFinished
 
     public bool HasLoadedVideo { get; private set; }
     public bool HasLoadedBackgroundImage { get; private set; }
-    private string videoPath;
+    private string videoUrl;
 
     private float nextSyncTimeInSeconds;
 
@@ -161,15 +161,16 @@ public class SongVideoPlayer : MonoBehaviour, INeedInjection, IInjectionFinished
         }
     }
 
-    public void LoadVideo(string videoPath)
+    public void LoadVideo(string videoUrl)
     {
-        if (!File.Exists(videoPath))
+        if (!WebRequestUtils.IsHttpOrHttpsUri(videoUrl)
+            && !File.Exists(videoUrl.Replace("file://", "")))
         {
-            Debug.LogWarning("Video does not exist: " + videoPath);
+            Debug.LogWarning("Video does not exist: " + videoUrl);
             return;
         }
 
-        videoPlayer.url = "file://" + videoPath;
+        videoPlayer.url = videoUrl;
         // The url is empty if loading the video failed.
         HasLoadedVideo = !string.IsNullOrEmpty(videoPlayer.url);
         // For now, only load the video. Starting it is done from the outside.
@@ -353,11 +354,19 @@ public class SongVideoPlayer : MonoBehaviour, INeedInjection, IInjectionFinished
             return;
         }
 
-        videoPath = "";
+        videoUrl = "";
         if (!string.IsNullOrEmpty(songMeta.Video))
         {
-            videoPath = songMeta.Directory + Path.DirectorySeparatorChar + songMeta.Video;
-            LoadVideo(videoPath);
+            if (WebRequestUtils.IsHttpOrHttpsUri(songMeta.Video))
+            {
+                videoUrl = songMeta.Video;
+                LoadVideo(videoUrl);
+            }
+            else
+            {
+                videoUrl = "file://" + songMeta.Directory + Path.DirectorySeparatorChar + songMeta.Video;
+                LoadVideo(videoUrl);
+            }
         }
     }
 

--- a/UltraStar Play/Assets/Common/Video/SongVideoPlayer/SongVideoPlayer.cs
+++ b/UltraStar Play/Assets/Common/Video/SongVideoPlayer/SongVideoPlayer.cs
@@ -161,16 +161,15 @@ public class SongVideoPlayer : MonoBehaviour, INeedInjection, IInjectionFinished
         }
     }
 
-    public void LoadVideo(string videoUrl)
+    public void LoadVideo(string uri)
     {
-        if (!WebRequestUtils.IsHttpOrHttpsUri(videoUrl)
-            && !File.Exists(videoUrl.Replace("file://", "")))
+        if (!WebRequestUtils.ResourceExists(uri))
         {
-            Debug.LogWarning("Video does not exist: " + videoUrl);
+            Debug.LogWarning("Video file resource does not exist: " + uri);
             return;
         }
 
-        videoPlayer.url = videoUrl;
+        videoPlayer.url = uri;
         // The url is empty if loading the video failed.
         HasLoadedVideo = !string.IsNullOrEmpty(videoPlayer.url);
         // For now, only load the video. Starting it is done from the outside.
@@ -300,16 +299,14 @@ public class SongVideoPlayer : MonoBehaviour, INeedInjection, IInjectionFinished
             return;
         }
 
-        string backgroundImagePath = SongMeta.Directory + Path.DirectorySeparatorChar + SongMeta.Background;
-        if (File.Exists(backgroundImagePath))
+        string backgroundUri = SongMetaUtils.GetBackgroundUri(SongMeta);
+        if (!WebRequestUtils.ResourceExists(backgroundUri))
         {
-            LoadBackgroundImage(backgroundImagePath);
-        }
-        else
-        {
-            Debug.LogWarning("Background image '" + backgroundImagePath + "'does not exist. Showing cover instead.");
+            Debug.LogWarning("Showing cover image because background image resource does not exist: " + backgroundUri);
             ShowCoverImageAsBackground();
         }
+
+        LoadBackgroundImage(backgroundUri);
     }
 
     private void ShowCoverImageAsBackground()
@@ -319,15 +316,14 @@ public class SongVideoPlayer : MonoBehaviour, INeedInjection, IInjectionFinished
             return;
         }
 
-        string coverImagePath = SongMeta.Directory + Path.DirectorySeparatorChar + SongMeta.Cover;
-        if (File.Exists(coverImagePath))
+        string coverUri = SongMetaUtils.GetCoverUri(SongMeta);
+        if (!WebRequestUtils.ResourceExists(coverUri))
         {
-            LoadBackgroundImage(coverImagePath);
+            Debug.LogWarning("Cover image resource does not exist: " + coverUri);
+            return;
         }
-        else
-        {
-            Debug.LogWarning("Cover image '" + coverImagePath + "'does not exist.");
-        }
+
+        LoadBackgroundImage(coverUri);
     }
 
     private void LoadBackgroundImage(string imagePath)

--- a/UltraStar Play/Assets/Common/Video/SongVideoPlayer/SongVideoPlayer.cs
+++ b/UltraStar Play/Assets/Common/Video/SongVideoPlayer/SongVideoPlayer.cs
@@ -64,7 +64,6 @@ public class SongVideoPlayer : MonoBehaviour, INeedInjection, IInjectionFinished
 
     public bool HasLoadedVideo { get; private set; }
     public bool HasLoadedBackgroundImage { get; private set; }
-    private string videoUrl;
 
     private float nextSyncTimeInSeconds;
 
@@ -328,29 +327,17 @@ public class SongVideoPlayer : MonoBehaviour, INeedInjection, IInjectionFinished
         });
     }
 
-    private void InitVideo(SongMeta songMeta)
+    private void InitVideo(SongMeta initSongMeta)
     {
         UnloadVideo();
 
-        if (songMeta == null)
+        if (initSongMeta == null
+            || initSongMeta.Video.IsNullOrEmpty())
         {
             return;
         }
 
-        videoUrl = "";
-        if (!string.IsNullOrEmpty(songMeta.Video))
-        {
-            if (WebRequestUtils.IsHttpOrHttpsUri(songMeta.Video))
-            {
-                videoUrl = songMeta.Video;
-                LoadVideo(videoUrl);
-            }
-            else
-            {
-                videoUrl = "file://" + songMeta.Directory + Path.DirectorySeparatorChar + songMeta.Video;
-                LoadVideo(videoUrl);
-            }
-        }
+        LoadVideo(SongMetaUtils.GetVideoUri(initSongMeta));
     }
 
     void OnEnable()

--- a/UltraStar Play/Assets/Editor/Tests/PitchDetectionTests.cs
+++ b/UltraStar Play/Assets/Editor/Tests/PitchDetectionTests.cs
@@ -34,8 +34,8 @@ public class PitchDetectionTests
         foreach (KeyValuePair<string, string> pathAndNoteName in pathToExpectedMidiNoteNameMap)
         {
             // Load the audio clip
-            string path = pathAndNoteName.Key;
-            AudioClip audioClip = AudioUtils.GetAudioClipUncached(path, false);
+            string uri = "file://" + pathAndNoteName.Key;
+            AudioClip audioClip = AudioUtils.GetAudioClipUncached(uri, false);
             float[] samples = new float[audioClip.samples];
             audioClip.GetData(samples, 0);
 
@@ -45,11 +45,11 @@ public class PitchDetectionTests
             PitchEvent pitchEvent = audioSamplesAnalyzer.ProcessAudioSamples(samples, 0, samples.Length - 1, micProfile);
 
             // Check result
-            Assert.NotNull(pitchEvent, $"No pitch detected when analyzing {path}");
+            Assert.NotNull(pitchEvent, $"No pitch detected when analyzing audio resource {uri}");
             string expectedName = pathAndNoteName.Value;
             string analyzedName = MidiUtils.GetAbsoluteName(pitchEvent.MidiNote);
             Assert.AreEqual(expectedName, analyzedName,
-                $"Expected {expectedName} but was {analyzedName} when analyzing {path}");
+                $"Expected {expectedName} but was {analyzedName} when analyzing audio resource {uri}");
         }
     }
 

--- a/UltraStar Play/Assets/Scenes/Sing/SingScene.unity
+++ b/UltraStar Play/Assets/Scenes/Sing/SingScene.unity
@@ -292,7 +292,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 04e8e8353cf7d75419d03321d0098a54, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  defaultSongName: Kryptonite
+  defaultSongName: On the run
   defaultSongNamePasteBin: 'Summer Wine
 
     Me And My Broken Heart
@@ -309,7 +309,9 @@ MonoBehaviour:
 
     Rockabye ft. Sean Paul & Anne-Marie
 
-    Kryptonite'
+    Kryptonite
+
+    On the run'
 --- !u!4 &242235910
 Transform:
   m_ObjectHideFlags: 0

--- a/UltraStar Play/Assets/Scenes/SongEditor/SongEditorSceneController.cs
+++ b/UltraStar Play/Assets/Scenes/SongEditor/SongEditorSceneController.cs
@@ -169,7 +169,7 @@ public class SongEditorSceneController : MonoBehaviour, IBinder, INeedInjection
             using (new DisposableStopwatch($"Created audio waveform in <millis> ms"))
             {
                 // For drawing the waveform, the AudioClip must not be streamed. All data must have been fully loaded.
-                AudioClip audioClip = AudioManager.Instance.LoadAudioClip(SongMetaUtils.GetAbsoluteSongAudioPath(SongMeta), false);
+                AudioClip audioClip = AudioManager.Instance.LoadAudioClip(SongMetaUtils.GetAudioUri(SongMeta), false);
                 audioWaveFormInitialized = true;
                 audioWaveFormVisualizer.DrawWaveFormMinAndMaxValues(audioClip);
             }

--- a/UltraStar Play/Assets/Scenes/SongEditor/SongEditorSceneController.cs
+++ b/UltraStar Play/Assets/Scenes/SongEditor/SongEditorSceneController.cs
@@ -169,7 +169,7 @@ public class SongEditorSceneController : MonoBehaviour, IBinder, INeedInjection
             using (new DisposableStopwatch($"Created audio waveform in <millis> ms"))
             {
                 // For drawing the waveform, the AudioClip must not be streamed. All data must have been fully loaded.
-                AudioClip audioClip = AudioManager.Instance.LoadAudioClip(SongMetaUtils.GetAudioUri(SongMeta), false);
+                AudioClip audioClip = AudioManager.Instance.LoadAudioClipFromUri(SongMetaUtils.GetAudioUri(SongMeta), false);
                 audioWaveFormInitialized = true;
                 audioWaveFormVisualizer.DrawWaveFormMinAndMaxValues(audioClip);
             }

--- a/UltraStar Play/Assets/Scenes/SongSelect/Preview/SongPreviewControl.cs
+++ b/UltraStar Play/Assets/Scenes/SongSelect/Preview/SongPreviewControl.cs
@@ -97,7 +97,8 @@ public class SongPreviewControl : MonoBehaviour, INeedInjection
     public void StartSongPreview(SongSelection songSelection)
     {
         if (songRouletteControl.IsDrag
-            || songRouletteControl.IsFlickGesture)
+            || songRouletteControl.IsFlickGesture
+            || !gameObject.activeInHierarchy)
         {
             return;
         }

--- a/UltraStar Play/Assets/Scenes/SongSelect/SongRoulette/SongEntryControl.cs
+++ b/UltraStar Play/Assets/Scenes/SongSelect/SongRoulette/SongEntryControl.cs
@@ -183,17 +183,23 @@ public class SongEntryControl : INeedInjection, IDragListener<GeneralDragEvent>,
 
     private void UpdateCover(SongMeta coverSongMeta)
     {
-        string coverPath = coverSongMeta.Directory + Path.DirectorySeparatorChar + coverSongMeta.Cover;
-        if (File.Exists(coverPath))
+        string coverUri = SongMetaUtils.GetCoverUri(coverSongMeta);
+        if (coverUri.IsNullOrEmpty())
         {
-            Sprite sprite = ImageManager.LoadSprite(coverPath);
-            songImageOuter.style.backgroundImage = new StyleBackground(sprite);
-            songImageInner.style.backgroundImage = new StyleBackground(sprite);
+            return;
         }
-        else
+
+        if (!WebRequestUtils.ResourceExists(coverUri))
         {
-            Debug.Log("Cover does not exist: " + coverPath);
+            Debug.Log("Cover image resource does not exist: " + coverUri);
+            return;
         }
+
+        ImageManager.LoadSpriteFromUri(coverUri, loadedSprite =>
+        {
+            songImageOuter.style.backgroundImage = new StyleBackground(loadedSprite);
+            songImageInner.style.backgroundImage = new StyleBackground(loadedSprite);
+        });
     }
 
     public void OnBeginDrag(GeneralDragEvent dragEvent)

--- a/UltraStar Play/Assets/Scenes/SongSelect/SongRoulette/SongEntryControl.cs
+++ b/UltraStar Play/Assets/Scenes/SongSelect/SongRoulette/SongEntryControl.cs
@@ -186,7 +186,12 @@ public class SongEntryControl : INeedInjection, IDragListener<GeneralDragEvent>,
         string coverUri = SongMetaUtils.GetCoverUri(coverSongMeta);
         if (coverUri.IsNullOrEmpty())
         {
-            return;
+            // Try the background image as fallback
+            coverUri = SongMetaUtils.GetBackgroundUri(coverSongMeta);
+            if (coverUri.IsNullOrEmpty())
+            {
+                return;
+            }
         }
 
         if (!WebRequestUtils.ResourceExists(coverUri))

--- a/UltraStar Play/Assets/Scenes/SongSelect/SongSelectScene.unity
+++ b/UltraStar Play/Assets/Scenes/SongSelect/SongSelectScene.unity
@@ -957,6 +957,11 @@ PrefabInstance:
       propertyPath: m_Name
       value: SongAudioPlayer
       objectReference: {fileID: 0}
+    - target: {fileID: 7998560839839612125, guid: b6d86aaa88ec3d7479a2f42f735481a1,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 7998560839839612128, guid: b6d86aaa88ec3d7479a2f42f735481a1,
         type: 3}
       propertyPath: audioPlayer

--- a/UltraStar Play/Assets/Scenes/SongSelect/SongSelectSceneControl.cs
+++ b/UltraStar Play/Assets/Scenes/SongSelect/SongSelectSceneControl.cs
@@ -316,6 +316,9 @@ public class SongSelectSceneControl : MonoBehaviour, INeedInjection, IBinder, IT
         inputManager.InputDeviceChangeEventStream.Subscribe(_ => UpdateInputLegend());
 
         focusableNavigator.FocusSongRoulette();
+
+        songAudioPlayer.AudioClipLoadedEventStream
+            .Subscribe(_ => UpdateSongDurationLabel(songAudioPlayer.DurationOfSongInMillis));
     }
 
     private void UpdateNextAndPreviousSongButtonLabels()
@@ -370,7 +373,7 @@ public class SongSelectSceneControl : MonoBehaviour, INeedInjection, IBinder, IT
         noSongsFoundLabel.SetVisibleByDisplay(songMetas.IsNullOrEmpty());
     }
 
-    void Update()
+    private void Update()
     {
         // Check if new songs were loaded in background. Update scene if necessary.
         if (songMetas.Count != SongMetaManager.Instance.GetSongMetas().Count
@@ -413,7 +416,10 @@ public class SongSelectSceneControl : MonoBehaviour, INeedInjection, IBinder, IT
             : "";
         songIndexLabel.text = (selection.SongIndex + 1) + "\nof " + selection.SongsCount;
 
-        UpdateSongDurationLabel(selectedSong);
+        // The song duration requires loading the audio file.
+        // Loading every song only to show its duration is slow (e.g. when scrolling through songs).
+        // Instead, the label is updated when the AudioClip has been loaded.
+        durationLabel.text = "";
 
         bool hasVideo = !string.IsNullOrEmpty(selectedSong.Video);
         videoIndicator.SetVisibleByVisibility(hasVideo);
@@ -431,11 +437,10 @@ public class SongSelectSceneControl : MonoBehaviour, INeedInjection, IBinder, IT
         }
     }
 
-    private void UpdateSongDurationLabel(SongMeta songMeta)
+    private void UpdateSongDurationLabel(double durationInMillis)
     {
-        songAudioPlayer.Init(songMeta);
-        int min = (int)Math.Floor(songAudioPlayer.DurationOfSongInMillis / 1000 / 60);
-        int seconds = (int)Math.Floor((songAudioPlayer.DurationOfSongInMillis / 1000) % 60);
+        int min = (int)Math.Floor(durationInMillis / 1000 / 60);
+        int seconds = (int)Math.Floor((durationInMillis / 1000) % 60);
         durationLabel.text = $"{min}:{seconds.ToString().PadLeft(2, '0')}";
     }
 

--- a/UltraStar Play/Assets/Scenes/SongSelect/SongSelectSceneControl.cs
+++ b/UltraStar Play/Assets/Scenes/SongSelect/SongSelectSceneControl.cs
@@ -624,10 +624,12 @@ public class SongSelectSceneControl : MonoBehaviour, INeedInjection, IBinder, IT
             // Check that the audio file exists
             if (!WebRequestUtils.IsHttpOrHttpsUri(SelectedSong.Mp3))
             {
-                string audioPath = SongMetaUtils.GetAbsoluteSongAudioPath(SelectedSong);
-                if (!File.Exists(audioPath))
+                string audioUri = SongMetaUtils.GetAudioUri(SelectedSong);
+                if (!WebRequestUtils.ResourceExists(audioUri))
                 {
-                    uiManager.CreateNotificationVisualElement("Audio file does not exist: " + audioPath);
+                    string message = "Audio file resource does not exist: " + audioUri;
+                    Debug.Log(message);
+                    uiManager.CreateNotificationVisualElement(message);
                     return;
                 }
             }
@@ -636,7 +638,9 @@ public class SongSelectSceneControl : MonoBehaviour, INeedInjection, IBinder, IT
             songAudioPlayer.Init(SelectedSong);
             if (!songAudioPlayer.HasAudioClip)
             {
-                uiManager.CreateNotificationVisualElement("Audio file could not be loaded.\nPlease use a supported format.");
+                string message = $"Audio file '{SelectedSong.Mp3}' could not be loaded.\nPlease use a supported format.";
+                Debug.Log(message);
+                uiManager.CreateNotificationVisualElement(message);
                 return;
             }
 

--- a/UltraStar Play/Assets/Scenes/SongSelect/SongSelectSceneControl.cs
+++ b/UltraStar Play/Assets/Scenes/SongSelect/SongSelectSceneControl.cs
@@ -622,11 +622,14 @@ public class SongSelectSceneControl : MonoBehaviour, INeedInjection, IBinder, IT
             }
 
             // Check that the audio file exists
-            string audioPath = SongMetaUtils.GetAbsoluteSongAudioPath(SelectedSong);
-            if (!File.Exists(audioPath))
+            if (!WebRequestUtils.IsHttpOrHttpsUri(SelectedSong.Mp3))
             {
-                uiManager.CreateNotificationVisualElement("Audio file does not exist: " + audioPath);
-                return;
+                string audioPath = SongMetaUtils.GetAbsoluteSongAudioPath(SelectedSong);
+                if (!File.Exists(audioPath))
+                {
+                    uiManager.CreateNotificationVisualElement("Audio file does not exist: " + audioPath);
+                    return;
+                }
             }
 
             // Check that the used audio format can be loaded.


### PR DESCRIPTION
### What does this PR do?

- allow the use of http and https URIs as audio, video, and image in song files.
- fix performance issue in the SongSelectScene.
    - every audio file was loaded, just to show its duration. This is why scrolling was stuttering.

**Streaming media files**
For example, consider [Joshua Morin - On the run](https://github.com/UltraStar-Deluxe/songs/tree/master/Creative%20Commons/Joshua%20Morin%20-%20On%20the%20run).
This UltraStar song can now be written as:
```
#TITLE:On the run
#ARTIST:Joshua Morin
#EDITION:Creative Commons
#LANGUAGE:English
#MP3:https://raw.githubusercontent.com/UltraStar-Deluxe/songs/master/Creative%20Commons/Joshua%20Morin%20-%20On%20the%20run/audio.ogg
#COVER:https://raw.githubusercontent.com/UltraStar-Deluxe/songs/master/Creative%20Commons/Joshua%20Morin%20-%20On%20the%20run/cover.jpg
#BACKGROUND:https://raw.githubusercontent.com/UltraStar-Deluxe/songs/master/Creative%20Commons/Joshua%20Morin%20-%20On%20the%20run/background.jpg
#VIDEO:http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4
#BPM:297,5
#GAP:11250
: 0 3 9 So
: 6 4 11  far
: 12 2 9  a
: 16 4 11 way
* 25 8 14  etc.
- 44
E
```

Note that the URI must point directly to the media file (YouTube links won't work).

**Supported formats**
The supported formats are the ones that Unity supports natively for streaming.
This is platform dependent, just like before . As a rule of thumb:
- ogg should work on all platforms.
- mp3 does not work.
    - We use an external lib to play mp3 files
    - One could download the bytes upfront. But this would be a long running download (in contrast, ogg is streamed on-the-fly by Unity). Thus, I argue to focus on ogg.
- mp4 does not work on Linux (see #246). But it should work on Windows and Mac. It might also work on Android and iOS, not sure.
- VP8 as video should work on all platforms, but might be slow if there is no hardware support.

**File extension**
The URI must end with the file extension of the used format.
For example, an ogg audio URI must end with `.ogg` and a VP8 video URI must end with `.vp8`

### Motivation

- Beeing able to stream the media files makes the song access/distribution easier, especially on mobile platforms.
- It should be fairly simple now to create a song repo.
    - One could add some authentication to the media requests (e.g. via HTTP basic auth in the request's header). This could be used to allow access only for authenticated users, e.g., to a private repository or commercial song service. ( FYI @bohning  )

### Additional Notes

This was surprisingly simple. Would have done it earlier if I knew this :)
