### PR TITLE
Anst/improvements

### DIFF
--- a/UltraStar Play/Assets/Common/Model/Song/Builder/SongMetaBuilder.cs
+++ b/UltraStar Play/Assets/Common/Model/Song/Builder/SongMetaBuilder.cs
@@ -99,9 +99,12 @@ public static class SongMetaBuilder
                 {
                     if (otherFields.ContainsKey(tag))
                     {
-                        throw new SongMetaBuilderException("Cannot set '" + tag + "' twice in file " + path);
+                        Debug.LogWarning($"Cannot set '{tag}' twice in file {path}");
                     }
-                    otherFields.Add(tag, val);
+                    else
+                    {
+                        otherFields[tag] = val;
+                    }
                 }
             }
 

--- a/UltraStar Play/Assets/Common/UI/Dialogs/PathInputDialogControl.cs
+++ b/UltraStar Play/Assets/Common/UI/Dialogs/PathInputDialogControl.cs
@@ -1,10 +1,18 @@
 ﻿using System;
 using System.IO;
+using UniRx;
 
 public class PathInputDialogControl : TextInputDialogControl
 {
     public override void OnInjectionFinished()
     {
+        if (backslashReplacingTextFieldControl == null)
+        {
+            backslashReplacingTextFieldControl = new PathTextFieldControl(textField);
+            backslashReplacingTextFieldControl.ValueChangedEventStream
+                .Subscribe(newValue => ValidateValue(newValue, true));
+        }
+
         base.OnInjectionFinished();
 
         ValidateValueCallback = newValue =>

--- a/UltraStar Play/Assets/Common/UI/Dialogs/TextInputDialogControl.cs
+++ b/UltraStar Play/Assets/Common/UI/Dialogs/TextInputDialogControl.cs
@@ -26,7 +26,7 @@ public class TextInputDialogControl : AbstractDialogControl, IInjectionFinishedL
     [Inject(UxmlName = R.UxmlNames.cancelButton)]
     protected Button cancelButton;
 
-    private BackslashReplacingTextFieldControl backslashReplacingTextFieldControl;
+    protected BackslashReplacingTextFieldControl backslashReplacingTextFieldControl;
 
     private readonly Subject<string> submitValueEventStream = new Subject<string>();
     public IObservable<string> SubmitValueEventStream => submitValueEventStream;
@@ -123,7 +123,7 @@ public class TextInputDialogControl : AbstractDialogControl, IInjectionFinishedL
         }
     }
 
-    private void ValidateValue(string textValue, bool showMessageIfInvalid)
+    protected void ValidateValue(string textValue, bool showMessageIfInvalid)
     {
         if (ValidateValueCallback == null)
         {

--- a/UltraStar Play/Assets/Common/UIToolkit/BackslashReplacingTextFieldControl.cs
+++ b/UltraStar Play/Assets/Common/UIToolkit/BackslashReplacingTextFieldControl.cs
@@ -16,15 +16,18 @@ using UniRx;
  */
 public class BackslashReplacingTextFieldControl
 {
-    private const string BackslashReplacement = "＼";
+    private const string DefaultBackslashReplacement = "＼";
 
     private TextField textField;
 
     private readonly Subject<string> valueChangedEventStream = new Subject<string>();
     public IObservable<string> ValueChangedEventStream => valueChangedEventStream;
 
-    public BackslashReplacingTextFieldControl(TextField textField)
+    private readonly string backslashReplacement;
+
+    public BackslashReplacingTextFieldControl(TextField textField, string backslashReplacement = DefaultBackslashReplacement)
     {
+        this.backslashReplacement = backslashReplacement;
         textField.RegisterValueChangedCallback(evt =>
         {
             string newValueEscaped = EscapeBackslashes(evt.newValue);
@@ -34,16 +37,16 @@ public class BackslashReplacingTextFieldControl
             valueChangedEventStream.OnNext(newValueUnescaped);
         });
 
-        textField.value = textField.value.Replace("\\", BackslashReplacement);
+        textField.value = textField.value.Replace("\\", backslashReplacement);
     }
 
-    public static string EscapeBackslashes(string text)
+    public string EscapeBackslashes(string text)
     {
-        return text.Replace("\\", BackslashReplacement);
+        return text.Replace("\\", backslashReplacement);
     }
 
-    public static string UnescapeBackslashes(string text)
+    public string UnescapeBackslashes(string text)
     {
-        return text.Replace(BackslashReplacement, "\\");
+        return text.Replace(backslashReplacement, "\\");
     }
 }

--- a/UltraStar Play/Assets/Common/UIToolkit/Drag/AbstractDragControl.cs
+++ b/UltraStar Play/Assets/Common/UIToolkit/Drag/AbstractDragControl.cs
@@ -36,6 +36,8 @@ public abstract class AbstractDragControl<EVENT> : INeedInjection, IInjectionFin
 
     private readonly List<IDisposable> disposables = new List<IDisposable>();
 
+    public IReadOnlyCollection<int> ButtonFilter { get; set; } = new List<int> { 0, 1, 2 };
+
     public virtual void OnInjectionFinished()
     {
         this.panelHelper = new PanelHelper(uiDocument);
@@ -70,6 +72,12 @@ public abstract class AbstractDragControl<EVENT> : INeedInjection, IInjectionFin
 
     protected virtual void OnPointerDown(IPointerEvent evt)
     {
+        if (!ButtonFilter.IsNullOrEmpty()
+            && !ButtonFilter.Contains(evt.button))
+        {
+            return;
+        }
+
         dragControlPointerDownEvent = new DragControlPointerEvent(evt);
         DragState.Value = EDragState.WaitingForDistanceThreshold;
     }
@@ -92,6 +100,12 @@ public abstract class AbstractDragControl<EVENT> : INeedInjection, IInjectionFin
 
     protected virtual void OnPointerUp(IPointerEvent evt)
     {
+        if (!ButtonFilter.IsNullOrEmpty()
+            && !ButtonFilter.Contains(evt.button))
+        {
+            return;
+        }
+
         if (DragState.Value == EDragState.Dragging)
         {
             OnEndDrag(new DragControlPointerEvent(evt));

--- a/UltraStar Play/Assets/Common/UIToolkit/PathTextFieldControl.cs
+++ b/UltraStar Play/Assets/Common/UIToolkit/PathTextFieldControl.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using UnityEngine.UIElements;
+using UniInject;
+using UniRx;
+
+// Disable warning about fields that are never assigned, their values are injected.
+#pragma warning disable CS0649
+
+public class PathTextFieldControl : BackslashReplacingTextFieldControl
+{
+    private const string BackslashReplacement = "/";
+
+    public PathTextFieldControl(TextField textField)
+        : base(textField, BackslashReplacement)
+    {
+    }
+}

--- a/UltraStar Play/Assets/Common/UIToolkit/PathTextFieldControl.cs.meta
+++ b/UltraStar Play/Assets/Common/UIToolkit/PathTextFieldControl.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 1dcd2eaeca5b498e965102a48c00deb7
+timeCreated: 1648152473

--- a/UltraStar Play/Assets/Resources/Translations/messages.properties
+++ b/UltraStar Play/Assets/Resources/Translations/messages.properties
@@ -240,7 +240,7 @@ options_sampleRate_auto=Auto
 
 # Content Download
 contentDownloadScene_title=Content Download
-contentDownloadScene_archiveUrlLabel=Archive URL (tar file)
+contentDownloadScene_archiveUrlLabel=Archive URL
 contentDownloadScene_startDownloadButton=Start Download
 contentDownloadScene_cancelDownloadButton=Cancel Download
 contentDownloadScene_status_finished=Finished

--- a/UltraStar Play/Assets/Resources/Translations/messages_de.properties
+++ b/UltraStar Play/Assets/Resources/Translations/messages_de.properties
@@ -240,7 +240,7 @@ options_sampleRate_auto=Auto
 
 # Content Download
 contentDownloadScene_title=Downloads
-contentDownloadScene_archiveUrlLabel=Archiv-URL (.tar-Datei)
+contentDownloadScene_archiveUrlLabel=Archiv-URL
 contentDownloadScene_startDownloadButton=Download Starten
 contentDownloadScene_cancelDownloadButton=Download Abbrechen
 contentDownloadScene_status_finished=Fertig

--- a/UltraStar Play/Assets/Scenes/Options/ContentDownload/ContentDownloadSceneUi.uxml
+++ b/UltraStar Play/Assets/Scenes/Options/ContentDownload/ContentDownloadSceneUi.uxml
@@ -13,9 +13,9 @@
                 </ui:VisualElement>
             </ui:VisualElement>
             <ui:VisualElement name="urlContainer" style="width: 100%; flex-direction: row; align-items: flex-start; margin-bottom: 5px;">
-                <ui:Label text="Archive URL (tar file)" display-tooltip-when-elided="true" name="urlLabel" style="width: auto; margin-right: 20px;" />
+                <ui:Label text="Archive URL" display-tooltip-when-elided="true" name="urlLabel" style="width: auto; margin-right: 20px;" />
                 <ui:VisualElement name="urlTextFieldContainer" style="flex-grow: 1;">
-                    <ui:TextField picking-mode="Ignore" text="http://my-url.com/my-file.tar" name="urlTextField" style="width: auto;" />
+                    <ui:TextField picking-mode="Ignore" text="http://my-url.com/my-file.zip" name="urlTextField" style="width: auto;" />
                     <ui:DropdownField index="-1" name="urlChooser" style="flex-grow: 1;" />
                 </ui:VisualElement>
             </ui:VisualElement>

--- a/UltraStar Play/Assets/Scenes/Options/SongLibraryOptions/SongLibraryOptionsSceneControl.cs
+++ b/UltraStar Play/Assets/Scenes/Options/SongLibraryOptions/SongLibraryOptionsSceneControl.cs
@@ -125,8 +125,8 @@ public class SongLibraryOptionsSceneControl : MonoBehaviour, INeedInjection, ITr
 
         TextField textField = result.Q<TextField>(R.UxmlNames.pathTextField);
         textField.value = songDir;
-        BackslashReplacingTextFieldControl backslashReplacingTextFieldControl = new BackslashReplacingTextFieldControl(textField);
-        backslashReplacingTextFieldControl.ValueChangedEventStream
+        PathTextFieldControl pathTextFieldControl = new PathTextFieldControl(textField);
+        pathTextFieldControl.ValueChangedEventStream
             .Subscribe(newValueUnescaped =>
             {
                 settings.GameSettings.songDirs[indexInList] = newValueUnescaped;

--- a/UltraStar Play/Assets/Scenes/SongEditor/LyricsArea/LyricsAreaControl.cs
+++ b/UltraStar Play/Assets/Scenes/SongEditor/LyricsArea/LyricsAreaControl.cs
@@ -62,6 +62,8 @@ public class LyricsAreaControl : INeedInjection, IInjectionFinishedListener
 
     public void OnInjectionFinished()
     {
+        BackslashReplacingTextFieldControl backslashReplacingTextFieldControl = null;
+
         voice = songMeta.GetVoices()[0];
         UpdateLyrics();
         textField.RegisterCallback<FocusEvent>(evt =>
@@ -72,7 +74,7 @@ public class LyricsAreaControl : INeedInjection, IInjectionFinishedListener
         {
             if (lyricsAreaMode == LyricsAreaMode.EditMode)
             {
-                OnEndEdit(BackslashReplacingTextFieldControl.UnescapeBackslashes(textField.text));
+                OnEndEdit(backslashReplacingTextFieldControl.UnescapeBackslashes(textField.text));
             }
         });
 
@@ -81,7 +83,7 @@ public class LyricsAreaControl : INeedInjection, IInjectionFinishedListener
         textField.doubleClickSelectsWord = true;
         textField.tripleClickSelectsLine = true;
 
-        BackslashReplacingTextFieldControl backslashReplacingTextFieldControl = new BackslashReplacingTextFieldControl(textField);
+        backslashReplacingTextFieldControl = new BackslashReplacingTextFieldControl(textField);
         // Replace white space with visible characters when in edit mode
         backslashReplacingTextFieldControl.ValueChangedEventStream
             .Subscribe(newValue =>

--- a/UltraStar Play/Assets/Scenes/SongSelect/Preview/SongPreviewControl.cs
+++ b/UltraStar Play/Assets/Scenes/SongSelect/Preview/SongPreviewControl.cs
@@ -201,7 +201,18 @@ public class SongPreviewControl : MonoBehaviour, INeedInjection
 
     private void StartAudioPreview(SongMeta songMeta, int previewStartInMillis)
     {
-        songAudioPlayer.Init(songMeta);
+        try
+        {
+            songAudioPlayer.Init(songMeta);
+        }
+        catch (Exception ex)
+        {
+            Debug.LogException(ex);
+            string errorMessage = $"Audio could not be loaded (artist: {songMeta.Artist}, title: {songMeta.Title})";
+            uiManager.CreateNotificationVisualElement(errorMessage);
+            return;
+        }
+        
         songAudioPlayer.PositionInSongInMillis = previewStartInMillis;
         songAudioPlayer.audioPlayer.volume = 0;
         if (songAudioPlayer.HasAudioClip)

--- a/UltraStar Play/Assets/Scenes/SongSelect/SongRoulette/SongEntryControl.cs
+++ b/UltraStar Play/Assets/Scenes/SongSelect/SongRoulette/SongEntryControl.cs
@@ -319,6 +319,8 @@ public class SongEntryControl : INeedInjection, IDragListener<GeneralDragEvent>,
             .WithRootVisualElement(songEntryUiRoot)
             .CreateAndInject<GeneralDragControl>();
         dragControl.AddListener(this);
+        // Only listen to left mouse button / touch gesture
+        dragControl.ButtonFilter = new List<int> { 0 };
 
         // Ignore button click after dragging
         dragControl.DragState.Subscribe(dragState =>
@@ -329,7 +331,7 @@ public class SongEntryControl : INeedInjection, IDragListener<GeneralDragEvent>,
             }
         });
         
-        songEntryUiRoot.RegisterCallback<PointerDownEvent>(_ => OnPointerDown(), TrickleDown.TrickleDown);
+        songEntryUiRoot.RegisterCallback<PointerDownEvent>(evt => OnPointerDown(evt), TrickleDown.TrickleDown);
         songEntryUiRoot.RegisterCallback<PointerUpEvent>(_ => OnPointerUp(), TrickleDown.TrickleDown);
 
         // Stop coroutine when dragging
@@ -344,8 +346,16 @@ public class SongEntryControl : INeedInjection, IDragListener<GeneralDragEvent>,
         UpdateTranslation();
     }
 
-    private void OnPointerDown()
+    private void OnPointerDown(IPointerEvent pointerEvent)
     {
+        if (pointerEvent.button == 1)
+        {
+            // Right click to open song menu
+            songRouletteControl.SelectSong(songMeta);
+            songRouletteControl.ShowSongMenuOverlay();
+            return;
+        }
+
         isPointerDown = true;
         StartShowSongMenuOverlayCoroutine();
     }


### PR DESCRIPTION
### What does this PR do?

This is a small PR.

- Added song repo with streaming assets for demonstration (see https://github.com/UltraStar-Deluxe/songs-stream)
    - Users do not need to download the > 200MB song pack upfront anymore
    - Therefor, I added support to download an extract ZIP archives (e.g. from GitHub).
- Fix last issues before creating new release
    - Right click to open song menu in SongSelect
        - Drag now listens only to left click
    - Replace backslash in TextField with forward slash.
        - The TextField is escaping stuff when entering backslash. The previous workaround with the "backslash-ish" Unicode character did not work in my Windows build for some reason.
    - The song parser was throwing an exception and aborting a song when unimportant tags occurred multiple times (e.g. genre, language)
        - It now logs a warning
