### PR TITLE
fix BuildInfoGenerator: wrong version number and missing commit hash

### DIFF
--- a/.github/workflows/build-companion-app.yml
+++ b/.github/workflows/build-companion-app.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch: {}
 
 env:
   UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}

--- a/.github/workflows/build-companion-app.yml
+++ b/.github/workflows/build-companion-app.yml
@@ -32,7 +32,6 @@ jobs:
         with:
           fetch-depth: 0
           lfs: true
-          submodules: recursive
       - uses: actions/cache@v2
         with:
           path: ${{ env.PROJECT_PATH }}/Library

--- a/.github/workflows/build-main-game.yml
+++ b/.github/workflows/build-main-game.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch: {}
 
 env:
   UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}

--- a/.github/workflows/build-main-game.yml
+++ b/.github/workflows/build-main-game.yml
@@ -32,7 +32,6 @@ jobs:
         with:
           fetch-depth: 0
           lfs: true
-          submodules: recursive
       - uses: actions/cache@v2
         with:
           path: ${{ env.PROJECT_PATH }}/Library

--- a/.github/workflows/test-companion-app.yml
+++ b/.github/workflows/test-companion-app.yml
@@ -31,7 +31,6 @@ jobs:
         with:
           fetch-depth: 0
           lfs: true
-          submodules: recursive
       - uses: actions/cache@v2
         with:
           path: ${{ env.PROJECT_PATH }}/Library

--- a/.github/workflows/test-companion-app.yml
+++ b/.github/workflows/test-companion-app.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - master
+  workflow_dispatch: {}
 
 env:
   UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}

--- a/.github/workflows/test-main-game.yml
+++ b/.github/workflows/test-main-game.yml
@@ -31,7 +31,6 @@ jobs:
         with:
           fetch-depth: 0
           lfs: true
-          submodules: recursive
       - uses: actions/cache@v2
         with:
           path: ${{ env.PROJECT_PATH }}/Library

--- a/.github/workflows/test-main-game.yml
+++ b/.github/workflows/test-main-game.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - master
+  workflow_dispatch: {}
 
 env:
   UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}

--- a/UltraStar Play/Packages/playshared/Editor/BuildInfoGenerator.cs
+++ b/UltraStar Play/Packages/playshared/Editor/BuildInfoGenerator.cs
@@ -69,11 +69,9 @@ public class BuildInfoGenerator : IPreprocessBuildWithReport
         // Return the value from the file because the C# API (PlayerSettings.bundleVersion) returns an older value
         // during the GitHub Actions build for whatever reason.
         string[] projectSettingsAssetLines = File.ReadAllLines("ProjectSettings/ProjectSettings.asset");
-        Debug.Log($"ProjectSettings.asset content:\n{projectSettingsAssetLines.JoinWith("\n")}");
         string bundleVersionLine = projectSettingsAssetLines.FirstOrDefault(line => line.Contains("bundleVersion:"));
-        Debug.Log($"bundleVersionLine: {bundleVersionLine}");
         string bundleVersion = bundleVersionLine.Replace("bundleVersion:", "").Trim();
-        Debug.Log($"bundleVersion: {bundleVersion}");
+        Debug.Log($"bundleVersion from ProjectSettings/ProjectSettings.asset: {bundleVersion}");
         return bundleVersion;
     }
 }

--- a/UltraStar Play/Packages/playshared/Editor/GitUtils.cs
+++ b/UltraStar Play/Packages/playshared/Editor/GitUtils.cs
@@ -65,40 +65,57 @@ public static class GitUtils
 
     public static string GetCurrentCommitShortHash()
     {
-        string currentDirectory = Directory.GetCurrentDirectory();
-        string firstGitFolderPath = null;
-        do
+        return GetMasterBranchCommitShortHash();
+
+        // TODO: running Git command to get the commit hash of the current branch fails with "fatal: unsafe repository ('/github/workspace' is owned by someone else)"
+        // string result = RunGitCommand("rev-parse --short --verify HEAD");
+
+        // Clean up whitespace around hash. (seems to just be the way this command returns :/ )
+        // commitShortHash = string.Join("", commitShortHash.Split(default(string[]), StringSplitOptions.RemoveEmptyEntries));
+        // Debug.Log("Current commit short hash: " + commitShortHash);
+        // return commitShortHash;
+    }
+
+    private static string GetMasterBranchCommitShortHash()
+    {
+        string gitFolderPath = GetGitFolder();
+        if (gitFolderPath.IsNullOrEmpty())
         {
-            ListDirectoryContent(currentDirectory);
-            DirectoryInfo parentDirectory = Directory.GetParent(currentDirectory);
-            currentDirectory = parentDirectory?.FullName;
-            if (firstGitFolderPath.IsNullOrEmpty()
-                && Directory.Exists(currentDirectory + "/.git"))
-            {
-                firstGitFolderPath = currentDirectory + "/.git";
-            }
-        } while (!currentDirectory.IsNullOrEmpty() && Directory.Exists(currentDirectory));
+            throw new BuildFailedException("No .git folder found");
+        }
 
         // Get commit hash from .git/refs/heads/master
-        string commitHashFile = firstGitFolderPath + "/refs/heads/master";
+        string commitHashFile = gitFolderPath + "/refs/heads/master";
+        if (!File.Exists(commitHashFile))
+        {
+            throw new BuildFailedException($"No file with commit hash found inside .git folder (tried file path: {commitHashFile})");
+        }
+
         Debug.Log($"commitHashFile: {commitHashFile}");
         string commitHash = File.ReadAllText(commitHashFile);
         Debug.Log($"commitHash: {commitHash}");
         string commitShortHash = commitHash[..8];
         Debug.Log($"commitShortHash: {commitShortHash}");
-
-        // Alternative: run git command
-        // string result = RunGitCommand("rev-parse --short --verify HEAD");
-
-        // Clean up whitespace around hash. (seems to just be the way this command returns :/ )
-        // result = string.Join("", result.Split(default(string[]), StringSplitOptions.RemoveEmptyEntries));
-        // Debug.Log("Current commit short hash: " + result);
         return commitShortHash;
     }
 
-    private static void ListDirectoryContent(string path)
+    private static string GetGitFolder()
     {
-        string[] allFolders = Directory.GetFiles(path, "*.*", SearchOption.TopDirectoryOnly);
-        allFolders.ForEach(folder => Debug.Log(folder));
+        Debug.Log("Searching .git folder");
+        string currentDirectory = Directory.GetCurrentDirectory();
+        do
+        {
+            Debug.Log($"currentDirectory: {currentDirectory}");
+            if (Directory.Exists(currentDirectory + "/.git"))
+            {
+                string gitFolder = currentDirectory + "/.git";
+                Debug.Log($"Found .git folder: {gitFolder}");
+                return gitFolder;
+            }
+            DirectoryInfo parentDirectory = Directory.GetParent(currentDirectory);
+            currentDirectory = parentDirectory?.FullName;
+        } while (!currentDirectory.IsNullOrEmpty() && Directory.Exists(currentDirectory));
+
+        return null;
     }
 }

--- a/UltraStar Play/Packages/playshared/Runtime/Util/Extensions/CollectionExtensions.cs
+++ b/UltraStar Play/Packages/playshared/Runtime/Util/Extensions/CollectionExtensions.cs
@@ -29,9 +29,14 @@ public static class CollectionExtensions
         }
     }
 
-    public static string ToCsv<T>(this IEnumerable<T> enumerable, string separator = ",", string prefix = "[", string suffix = "]")
+    public static string JoinWith<T>(this IEnumerable<T> enumerable, string separator, string prefix = "", string suffix = "")
     {
         return prefix + string.Join(separator, enumerable) + suffix;
+    }
+
+    public static string ToCsv<T>(this IEnumerable<T> enumerable, string separator = ",", string prefix = "[", string suffix = "]")
+    {
+        return enumerable.JoinWith(separator, prefix, suffix);
     }
 
     public static void AddIfNotContains<T>(this ICollection<T> collection, T item)


### PR DESCRIPTION
### What does this PR do?

Unity's API returns a wrong value when using `ProjectSettings.bundleVersion`.
The value is now fetched directly from `ProjectSettings.asset` file, which contains the correct value.

Git has some issue such that it does not return the commit hash when running the GitHub Actions build.
The value is now fetched from file `.git/refs/heads/master` without using any Git commands.

Besides this, it also adds `workflow_dispatch` to the GitHub Actions config to start them manually.

### Closes Issue(s)

close #289

### Additional Notes

- This annoyance was preventing the new release. Will create a release shortly.
