### PR TITLE
Easier song folder config on Android

### DIFF
--- a/UltraStar Play/Assets/Common/Model/SettingsManager.cs
+++ b/UltraStar Play/Assets/Common/Model/SettingsManager.cs
@@ -76,9 +76,6 @@ public class SettingsManager : MonoBehaviour
             {
                 UnityEngine.Debug.LogWarning($"Settings file not found. Creating default settings at {loadedSettingsPath}.");
                 settings = new Settings();
-                // Can only access Application.persistentDataPath from main thread. Thus, set the default songDirs in a coroutine.
-                StartCoroutine(CoroutineUtils.ExecuteAfterDelayInFrames(1,
-                    () => settings.GameSettings.songDirs.Add(Application.persistentDataPath + "/Songs")));
                 Save();
                 return;
             }

--- a/UltraStar Play/Assets/Common/R/RMessages.cs
+++ b/UltraStar Play/Assets/Common/R/RMessages.cs
@@ -142,6 +142,9 @@ public static partial class R
         public static readonly string options_showFps = "options_showFps";
         public static readonly string options_showLyricsOnNotes = "options_showLyricsOnNotes";
         public static readonly string options_showPitchIndicator = "options_showPitchIndicator";
+        public static readonly string options_songLibrary_addInternalSongFolder = "options_songLibrary_addInternalSongFolder";
+        public static readonly string options_songLibrary_addSdCardSongFolder = "options_songLibrary_addSdCardSongFolder";
+        public static readonly string options_songLibrary_androidFolderHint = "options_songLibrary_androidFolderHint";
         public static readonly string options_songLibrary_button = "options_songLibrary_button";
         public static readonly string options_songLibrary_title = "options_songLibrary_title";
         public static readonly string options_sound_button = "options_sound_button";

--- a/UltraStar Play/Assets/Common/R/RUxmlNames.cs
+++ b/UltraStar Play/Assets/Common/R/RUxmlNames.cs
@@ -6,6 +6,8 @@ public static partial class R
         public const string a = "a";
         public const string aboutButton = "aboutButton";
         public const string aboutText = "aboutText";
+        public const string addAndroidInternalSongFolderButton = "addAndroidInternalSongFolderButton";
+        public const string addAndroidSdCardSongFolderButton = "addAndroidSdCardSongFolderButton";
         public const string addButton = "addButton";
         public const string adjustFollowingNotesContainer = "adjustFollowingNotesContainer";
         public const string adjustFollowingNotesLabel = "adjustFollowingNotesLabel";
@@ -13,6 +15,8 @@ public static partial class R
         public const string adminRightsContainer = "adminRightsContainer";
         public const string amplificationContainer = "amplificationContainer";
         public const string analyzeBeatsWithoutTargetNoteContainer = "analyzeBeatsWithoutTargetNoteContainer";
+        public const string androidSongFolderHintContainer = "androidSongFolderHintContainer";
+        public const string androidSongFolderHintLabel = "androidSongFolderHintLabel";
         public const string appOptionsButton = "appOptionsButton";
         public const string artistInputContainer = "artistInputContainer";
         public const string artistLabel = "artistLabel";
@@ -417,6 +421,7 @@ public static partial class R
         public const string sentenceLineSizeContainer = "sentenceLineSizeContainer";
         public const string sentenceLineSizeTextField = "sentenceLineSizeTextField";
         public const string sentenceRatingContainer = "sentenceRatingContainer";
+        public const string SentenceRatingUi = "SentenceRatingUi";
         public const string sentenceUiRoot = "sentenceUiRoot";
         public const string setBpmChangeNoteDurationButton = "setBpmChangeNoteDurationButton";
         public const string setBpmKeepNoteDurationButton = "setBpmKeepNoteDurationButton";

--- a/UltraStar Play/Assets/Scenes/Options/SongLibraryOptions/SongLibraryOptionsSceneUi.uxml
+++ b/UltraStar Play/Assets/Scenes/Options/SongLibraryOptions/SongLibraryOptionsSceneUi.uxml
@@ -11,6 +11,13 @@
                     </ui:VisualElement>
                 </ui:VisualElement>
             </ui:VisualElement>
+            <ui:VisualElement name="androidSongFolderHintContainer" style="width: 100%; margin-bottom: 10px; flex-shrink: 0;">
+                <ui:Label text="Android requires songs to be stored in the folder ..." display-tooltip-when-elided="true" name="androidSongFolderHintLabel" style="width: 100%; white-space: normal;" />
+                <ui:VisualElement name="buttonRow" style="align-items: center; justify-content: flex-start; flex-direction: row;">
+                    <ui:Button text="Add Internal Folder" display-tooltip-when-elided="true" name="addAndroidInternalSongFolderButton" style="width: auto;" />
+                    <ui:Button text="Add SD Card Folder" display-tooltip-when-elided="true" name="addAndroidSdCardSongFolderButton" style="width: auto;" />
+                </ui:VisualElement>
+            </ui:VisualElement>
             <ui:VisualElement name="songListContainer" style="width: 100%; flex-grow: 1; margin-bottom: 20px;">
                 <ui:ScrollView scroll-deceleration-rate="0,135" elasticity="0,1" vertical-scroller-visibility="AlwaysVisible" name="songList" class="roundCorners outline" style="width: 100%; height: 100%;" />
                 <ui:Button text="+" name="addButton" class="middleCenterText outline roundButton" style="position: absolute; bottom: 20px; right: 30px; font-size: 30px;" />

--- a/UltraStar Play/Packages/playshared/Runtime/Resources/Translations/messages.properties
+++ b/UltraStar Play/Packages/playshared/Runtime/Resources/Translations/messages.properties
@@ -224,6 +224,9 @@ options_internet_button=Internet
 
 options_songLibrary_title=Song Library
 options_songLibrary_button=Songs
+options_songLibrary_androidFolderHint=Android requires songs to be stored in the folder {androidAppSpecificStorageRelativePath}
+options_songLibrary_addSdCardSongFolder=Add SD Card Folder
+options_songLibrary_addInternalSongFolder=Add Internal Folder
 
 options_downloadSongs_title=Downloads
 options_downloadSongs_button=Download Songs

--- a/UltraStar Play/Packages/playshared/Runtime/Resources/Translations/messages_de.properties
+++ b/UltraStar Play/Packages/playshared/Runtime/Resources/Translations/messages_de.properties
@@ -225,6 +225,7 @@ options_internet_button=Internet
 
 options_songLibrary_title=Song-Bibliothek
 options_songLibrary_button=Songs
+options_songLibrary_androidFolderHint=Android erwartet Songs in dem Ordner {androidAppSpecificStorageRelativePath}
 
 options_downloadSongs_title=Downloads
 options_downloadSongs_button=Songs Runterladen

--- a/UltraStar Play/Packages/playshared/Runtime/Util/AndroidUtils.cs
+++ b/UltraStar Play/Packages/playshared/Runtime/Util/AndroidUtils.cs
@@ -1,0 +1,106 @@
+using System;
+using UnityEngine;
+
+public static class AndroidUtils
+{
+    /**
+     * Returns the path where this app can store data.
+     *
+     * Example return value: /storage/emulated/0/Android/data/com.Karaoke.UltraStarPlay/files
+     *
+     * @param sdCard if true, the path on the SD card is returned. Otherwise the path on non-removable memory hardware is returned.
+     */
+	public static string GetAppSpecificStorageAbsolutePath(bool sdCard)
+    {
+        // Note: Android uses the terms "internal storage", "primary external storage", and "secondary external storage".
+        // - internal storage: General storage, includes storage of other apps. Requires root access.
+        // - primary external storage: The app specific storage folder on the device (non-removable).
+        // - secondary external storage: The app specific storage folder on the sd card.
+#if UNITY_ANDROID
+        if (Application.isEditor)
+        {
+            // Return dummy values for testing.
+            return sdCard
+                ? "/storage/sdcard/0/Android/data/UltraStarPlay/files"
+                : "/storage/emulated/0/Android/data/UltraStarPlay/files";
+        }
+
+        using AndroidJavaClass unityPlayer = new AndroidJavaClass("com.unity3d.player.UnityPlayer");
+        using AndroidJavaObject context = unityPlayer.GetStatic<AndroidJavaObject>("currentActivity");
+        using AndroidJavaClass environment = new AndroidJavaClass("android.os.Environment");
+
+        // Get all available external file directories (emulated and sdCards)
+        AndroidJavaObject[] externalFilesDirectories = context.Call<AndroidJavaObject[]>("getExternalFilesDirs", (object)null);
+        for (int i = 0; i < externalFilesDirectories.Length; i++)
+        {
+            AndroidJavaObject directory = externalFilesDirectories[i];
+            string path = directory.Call<string>("getAbsolutePath");
+
+            // Check which one is the SD-Card.
+            bool isRemovable = environment.CallStatic<bool>("isExternalStorageRemovable", directory);
+            bool isEmulated = environment.CallStatic<bool>("isExternalStorageEmulated", directory);
+            if (isEmulated
+                && !sdCard)
+            {
+                return path;
+            }
+            else if (isRemovable
+                     && !isEmulated
+                     && sdCard)
+            {
+                return path;
+            }
+        }
+
+        // No storage found.
+        return "";
+#else
+        return "";
+#endif
+    }
+
+    /**
+     * Returns the path of the storage folder relative to the root path.
+     * This is the path when browsing the device for example on Windows.
+     *
+     * Example return value: Android/data/com.Karaoke.UltraStarPlay/files
+     */
+    public static string GetAppSpecificStorageRelativePath(bool sdCard)
+    {
+        string appSpecificStorageFolder = GetAppSpecificStorageAbsolutePath(sdCard);
+        if (appSpecificStorageFolder.IsNullOrEmpty())
+        {
+            return "";
+        }
+
+        string storageRootPath = GetStorageRootPath(sdCard);
+        if (storageRootPath.IsNullOrEmpty()
+            || appSpecificStorageFolder.Length <= storageRootPath.Length + 1)
+        {
+            return "";
+        }
+        return appSpecificStorageFolder.Substring(storageRootPath.Length + 1);
+    }
+
+    /**
+     * Returns the root path of the storage folder.
+     * Android mounts the storage at this path.
+     *
+     * Example return value: /storage/emulated/0
+     */
+    public static string GetStorageRootPath(bool sdCard)
+    {
+        string appSpecificStorageFolder = GetAppSpecificStorageAbsolutePath(sdCard);
+        if (appSpecificStorageFolder.IsNullOrEmpty())
+        {
+            return "";
+        }
+        int androidIndex = appSpecificStorageFolder.IndexOf("/Android/", StringComparison.InvariantCulture);
+        if (androidIndex >= 0)
+        {
+            return appSpecificStorageFolder.Substring(0, androidIndex);
+        }
+
+        return "";
+    }
+}

--- a/UltraStar Play/Packages/playshared/Runtime/Util/AndroidUtils.cs.meta
+++ b/UltraStar Play/Packages/playshared/Runtime/Util/AndroidUtils.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a3c29db400e6bb943ba482050d6746bb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### What does this PR do?

A small PR.
- show path that is required for song folders on Android
    - Android does not allow arbitrary access to the files system.
        - Notably txt files are only visible to Unity's C# file system API when paths are inside the app specific folder
        - The app specific folder can be found using Android's `getExternalFilesDirs`
            - I got the initial code to query this from a [blog post](http://anja-haumann.de/unity-how-to-save-on-sd-card/).
            - Don't be confused with Android's use of "internal storage" (requires root access), "primary external storage" (app specific storage on internal memory), "secondary external storage" (app specific storage on sd card)
        - fun fact: the app specific folder on the internal storage is the what Unity uses as `Application.persistentDataPath`
- added button to add the correct paths for SD card and internal storage
    - because Android mounts the storage at some paths that no normal user will be able to guess.
- changed initial songDirs of the settings
    - now set in LoadingSceneControl because `Application.persistentDataPath` must be run on main thread.
    - on Android it adds a path to both, internal and external storage
    - on other platforms, it adds a path to `Application.persistentDataPath`

Now, one can save a song library on an SD card and use it with Android.