### PR TITLE
search expressions via DynamicQueryable

### DIFF
--- a/UltraStar Play/Assets/.gitignore
+++ b/UltraStar Play/Assets/.gitignore
@@ -38,3 +38,9 @@ Plugins/Serilog/Serilog.Sinks.File.meta
 
 StreamingAssets/Input/UltraStarPlayInputActions.inputactions
 StreamingAssets/Input/UltraStarPlayInputActions.inputactions.meta
+
+Plugins/Jokenizer.Net/
+Plugins/Jokenizer.Net.meta
+
+Plugins/DynamicQueryable/
+Plugins/DynamicQueryable.meta

--- a/UltraStar Play/Assets/Common/R/RMessages.cs
+++ b/UltraStar Play/Assets/Common/R/RMessages.cs
@@ -208,6 +208,8 @@ public static partial class R
         public static readonly string songSelectScene_noSongsFound = "songSelectScene_noSongsFound";
         public static readonly string songSelectScene_onlineTopScoresTitle = "songSelectScene_onlineTopScoresTitle";
         public static readonly string songSelectScene_playlistDropdownTitle = "songSelectScene_playlistDropdownTitle";
+        public static readonly string songSelectScene_searchExpressionInfo = "songSelectScene_searchExpressionInfo";
+        public static readonly string songSelectScene_searchExpressionInfo_syntaxTips = "songSelectScene_searchExpressionInfo_syntaxTips";
         public static readonly string songSelectScene_searchPropertyDropdownTitle = "songSelectScene_searchPropertyDropdownTitle";
         public static readonly string songSelectScene_searchTextFieldHint = "songSelectScene_searchTextFieldHint";
         public static readonly string songSelectScene_songMenu_openSongEditor = "songSelectScene_songMenu_openSongEditor";

--- a/UltraStar Play/Assets/Common/R/RMessages.cs
+++ b/UltraStar Play/Assets/Common/R/RMessages.cs
@@ -208,6 +208,7 @@ public static partial class R
         public static readonly string songSelectScene_noSongsFound = "songSelectScene_noSongsFound";
         public static readonly string songSelectScene_onlineTopScoresTitle = "songSelectScene_onlineTopScoresTitle";
         public static readonly string songSelectScene_playlistDropdownTitle = "songSelectScene_playlistDropdownTitle";
+        public static readonly string songSelectScene_searchExpressionError = "songSelectScene_searchExpressionError";
         public static readonly string songSelectScene_searchExpressionInfo = "songSelectScene_searchExpressionInfo";
         public static readonly string songSelectScene_searchExpressionInfo_syntaxTips = "songSelectScene_searchExpressionInfo_syntaxTips";
         public static readonly string songSelectScene_searchPropertyDropdownTitle = "songSelectScene_searchPropertyDropdownTitle";

--- a/UltraStar Play/Assets/Common/R/RUxmlNames.cs
+++ b/UltraStar Play/Assets/Common/R/RUxmlNames.cs
@@ -74,6 +74,7 @@ public static partial class R
         public const string closeMenuOverlayButton = "closeMenuOverlayButton";
         public const string closePlayerSelectOverlayButton = "closePlayerSelectOverlayButton";
         public const string closePlaylistChooserDropdownButton = "closePlaylistChooserDropdownButton";
+        public const string closeSearchExpressionInfoButton = "closeSearchExpressionInfoButton";
         public const string closeSearchPropertyDropdownButton = "closeSearchPropertyDropdownButton";
         public const string closeSongOverlayButton = "closeSongOverlayButton";
         public const string colorContainer = "colorContainer";
@@ -173,6 +174,7 @@ public static partial class R
         public const string gridSizeContainer = "gridSizeContainer";
         public const string gridSizeTextField = "gridSizeTextField";
         public const string gridTitle = "gridTitle";
+        public const string helpIcon = "helpIcon";
         public const string helpSideBarContainer = "helpSideBarContainer";
         public const string helpTitle = "helpTitle";
         public const string hiddenContinueButton = "hiddenContinueButton";
@@ -191,6 +193,7 @@ public static partial class R
         public const string imageAsCursorContainer = "imageAsCursorContainer";
         public const string importMidiFileButton = "importMidiFileButton";
         public const string innerMenuOverlay = "innerMenuOverlay";
+        public const string innerSearchExpressionInfoOverlay = "innerSearchExpressionInfoOverlay";
         public const string innerSongDetailOverlay = "innerSongDetailOverlay";
         public const string innerTimeBar = "innerTimeBar";
         public const string innerTimeBarSentenceEntryContainer = "innerTimeBarSentenceEntryContainer";
@@ -296,6 +299,7 @@ public static partial class R
         public const string nameCharacterContainer = "nameCharacterContainer";
         public const string nameLabel = "nameLabel";
         public const string nameTextField = "nameTextField";
+        public const string networkConfigContainer = "networkConfigContainer";
         public const string nextCharacterButton = "nextCharacterButton";
         public const string nextItemButton = "nextItemButton";
         public const string nextItemIcon = "nextItemIcon";
@@ -341,6 +345,9 @@ public static partial class R
         public const string overviewAreaSentences = "overviewAreaSentences";
         public const string overviewAreaViewportIndicator = "overviewAreaViewportIndicator";
         public const string overviewAreaWaveform = "overviewAreaWaveform";
+        public const string ownHostContainer = "ownHostContainer";
+        public const string ownHostLabel = "ownHostLabel";
+        public const string ownHostTextField = "ownHostTextField";
         public const string partyButton = "partyButton";
         public const string pathTextField = "pathTextField";
         public const string pauseIcon = "pauseIcon";
@@ -424,6 +431,9 @@ public static partial class R
         public const string scrollView = "scrollView";
         public const string ScrollView = "ScrollView";
         public const string searchBarContainer = "searchBarContainer";
+        public const string searchExpressionInfoLabel = "searchExpressionInfoLabel";
+        public const string searchExpressionInfoOverlay = "searchExpressionInfoOverlay";
+        public const string searchExpressionInfoSyntaxTipsLabel = "searchExpressionInfoSyntaxTipsLabel";
         public const string searchIcon = "searchIcon";
         public const string searchPropertyButton = "searchPropertyButton";
         public const string searchPropertyDropdownContainer = "searchPropertyDropdownContainer";
@@ -460,6 +470,9 @@ public static partial class R
         public const string showLogOverlayButton = "showLogOverlayButton";
         public const string showLyricsAreaContainer = "showLyricsAreaContainer";
         public const string showLyricsAreaToggle = "showLyricsAreaToggle";
+        public const string showSearchExpressionInfoButton = "showSearchExpressionInfoButton";
+        public const string showSearchExpressionInfoContainer = "showSearchExpressionInfoContainer";
+        public const string showSearchExpressionInfoTitle = "showSearchExpressionInfoTitle";
         public const string showStatusBarContainer = "showStatusBarContainer";
         public const string showStatusBarToggle = "showStatusBarToggle";
         public const string showVideoAreaContainer = "showVideoAreaContainer";
@@ -570,6 +583,12 @@ public static partial class R
         public const string topRow = "topRow";
         public const string totalScore = "totalScore";
         public const string twoPlayerLayout = "twoPlayerLayout";
+        public const string udpPortOnClientContainer = "udpPortOnClientContainer";
+        public const string udpPortOnClientLabel = "udpPortOnClientLabel";
+        public const string udpPortOnClientTextField = "udpPortOnClientTextField";
+        public const string udpPortOnServerContainer = "udpPortOnServerContainer";
+        public const string udpPortOnServerLabel = "udpPortOnServerLabel";
+        public const string udpPortOnServerTextField = "udpPortOnServerTextField";
         public const string undoButton = "undoButton";
         public const string urlChooser = "urlChooser";
         public const string urlContainer = "urlContainer";

--- a/UltraStar Play/Assets/Common/R/RUxmlNames.cs
+++ b/UltraStar Play/Assets/Common/R/RUxmlNames.cs
@@ -431,6 +431,7 @@ public static partial class R
         public const string scrollView = "scrollView";
         public const string ScrollView = "ScrollView";
         public const string searchBarContainer = "searchBarContainer";
+        public const string searchErrorIcon = "searchErrorIcon";
         public const string searchExpressionInfoLabel = "searchExpressionInfoLabel";
         public const string searchExpressionInfoOverlay = "searchExpressionInfoOverlay";
         public const string searchExpressionInfoSyntaxTipsLabel = "searchExpressionInfoSyntaxTipsLabel";

--- a/UltraStar Play/Assets/Scenes/About/Texts/License-Overview.txt
+++ b/UltraStar Play/Assets/Scenes/About/Texts/License-Overview.txt
@@ -9,16 +9,19 @@ MIT License
 -----------
 - CSharpSynthForUnity
     - https://github.com/UltraStar-Deluxe/CSharpSynthForUnity
-    
+
+- DynamicQueryable
+    - https://github.com/umutozel/DynamicQueryable
+
 - FullSerializer
     - https://github.com/jacobdufault/fullserializer
-    
+
+- Jokenizer.Net
+    - https://github.com/umutozel/Jokenizer.Net
+
 - LeanTween
     - https://github.com/UltraStar-Deluxe/LeanTween
-    
-- NLayer
-    - https://github.com/naudio/NLayer
-    
+
 - SharpZipLib
     - https://github.com/icsharpcode/SharpZipLib
     
@@ -38,5 +41,3 @@ Apache License 2.0
 
 - Serilog
     - https://github.com/serilog/serilog
-
-

--- a/UltraStar Play/Assets/Scenes/SongSelect/Search/SongSearchControl.cs
+++ b/UltraStar Play/Assets/Scenes/SongSelect/Search/SongSearchControl.cs
@@ -55,6 +55,14 @@ public class SongSearchControl : INeedInjection, IInjectionFinishedListener, ITr
     [Inject(UxmlName = R.UxmlNames.lyricsPropertyContainer)]
     private VisualElement lyricsPropertyContainer;
 
+    [Inject(UxmlName = R.UxmlNames.searchErrorIcon)]
+    private VisualElement searchErrorIcon;
+
+    [Inject]
+    private Injector injector;
+
+    private TooltipControl searchErrorIconTooltipControl;
+
     public bool IsSearchPropertyDropdownVisible => searchPropertyDropdownOverlay.IsVisibleByDisplay();
 
     private HashSet<ESearchProperty> searchProperties = new();
@@ -70,6 +78,11 @@ public class SongSearchControl : INeedInjection, IInjectionFinishedListener, ITr
             searchTextFieldHint.SetVisibleByDisplay(GetRawSearchText().IsNullOrEmpty());
             searchChangedEventStream.OnNext(new SearchTextChangedEvent());
         });
+
+        searchErrorIcon.HideByDisplay();
+        searchErrorIconTooltipControl = injector
+            .WithRootVisualElement(searchErrorIcon)
+            .CreateAndInject<TooltipControl>();
 
         HideSearchPropertyDropdownOverlay();
         searchPropertyButton.RegisterCallbackButtonTriggered(() =>
@@ -148,6 +161,7 @@ public class SongSearchControl : INeedInjection, IInjectionFinishedListener, ITr
     public List<SongMeta> GetFilteredSongMetas(List<SongMeta> songMetas)
     {
         string searchExp = searchTextField.value;
+        searchErrorIcon.HideByDisplay();
         if (IsSearchExpression(searchExp))
         {
             try
@@ -160,6 +174,9 @@ public class SongSearchControl : INeedInjection, IInjectionFinishedListener, ITr
             catch (Exception e)
             {
                 Debug.Log($"Invalid search expression '{searchExp}': {e.Message}. Stack trace:\n{e.StackTrace}");
+                searchErrorIcon.ShowByDisplay();
+                searchErrorIconTooltipControl.TooltipText = TranslationManager.GetTranslation(R.Messages.songSelectScene_searchExpressionError,
+                    "errorDetails", e.Message);
                 return new List<SongMeta>();
             }
         }

--- a/UltraStar Play/Assets/Scenes/SongSelect/SongSelectSceneControl.cs
+++ b/UltraStar Play/Assets/Scenes/SongSelect/SongSelectSceneControl.cs
@@ -304,7 +304,9 @@ public class SongSelectSceneControl : MonoBehaviour, INeedInjection, IBinder, IT
 
         songIndexButton.RegisterCallbackButtonTriggered(() => songSearchControl.SetSearchText($"#{SelectedSongIndex + 1}"));
 
-        SongSearchControl.SearchChangedEventStream.Subscribe(_ => OnSearchTextChanged());
+        SongSearchControl.SearchChangedEventStream
+            .Throttle(new TimeSpan(0, 0, 0, 0, 500))
+            .Subscribe(_ => OnSearchTextChanged());
 
         PlaylistChooserControl.Selection.Subscribe(_ => UpdateFilteredSongs());
 

--- a/UltraStar Play/Assets/Scenes/SongSelect/SongSelectSceneControl.cs
+++ b/UltraStar Play/Assets/Scenes/SongSelect/SongSelectSceneControl.cs
@@ -215,11 +215,27 @@ public class SongSelectSceneControl : MonoBehaviour, INeedInjection, IBinder, IT
     [Inject(UxmlName = R.UxmlNames.noSongsFoundLabel)]
     private Label noSongsFoundLabel;
 
+    [Inject(UxmlName = R.UxmlNames.showSearchExpressionInfoButton)]
+    private Button showSearchExpressionInfoButton;
+
+    [Inject(UxmlName = R.UxmlNames.closeSearchExpressionInfoButton)]
+    private Button closeSearchExpressionInfoButton;
+
+    [Inject(UxmlName = R.UxmlNames.searchExpressionInfoOverlay)]
+    private VisualElement searchExpressionInfoOverlay;
+
+    [Inject(UxmlName = R.UxmlNames.searchExpressionInfoLabel)]
+    private Label searchExpressionInfoLabel;
+
+    [Inject(UxmlName = R.UxmlNames.searchExpressionInfoSyntaxTipsLabel)]
+    private Label searchExpressionInfoSyntaxTipsLabel;
+
     public PlaylistChooserControl PlaylistChooserControl { get; private set; }
 
     public bool IsPlayerSelectOverlayVisible => playerSelectOverlayContainer.IsVisibleByDisplay();
     public bool IsMenuOverlayVisible => menuOverlay.IsVisibleByDisplay();
     public bool IsSongDetailOverlayVisible => songDetailOverlay.IsVisibleByDisplay();
+    public bool IsSearchExpressionInfoOverlayVisible => searchExpressionInfoOverlay.IsVisibleByDisplay();
 
     private SongSearchControl songSearchControl;
     public SongSearchControl SongSearchControl
@@ -267,6 +283,7 @@ public class SongSelectSceneControl : MonoBehaviour, INeedInjection, IBinder, IT
         HidePlayerSelectOverlay();
         HideMenuOverlay();
         HideSongDetailOverlay();
+        HideSearchExpressionInfoOverlay();
 
         SongOrderPickerControl = new SongOrderPickerControl(songOrderItemPicker);
 
@@ -296,6 +313,8 @@ public class SongSelectSceneControl : MonoBehaviour, INeedInjection, IBinder, IT
                 ShowSongDetailOverlay();
             }
         });
+
+        InitSearchExpressionInfo();
 
         nextSongButton.RegisterCallbackButtonTriggered(() => songRouletteControl.SelectNextSong());
         previousSongButton.RegisterCallbackButtonTriggered(() => songRouletteControl.SelectPreviousSong());
@@ -347,6 +366,17 @@ public class SongSelectSceneControl : MonoBehaviour, INeedInjection, IBinder, IT
         new ScoreModeItemPickerControl(scoreModePicker)
             .Bind(() => settings.GameSettings.ScoreMode,
                 newValue => settings.GameSettings.ScoreMode = newValue);
+    }
+
+    public void HideSearchExpressionInfoOverlay()
+    {
+        searchExpressionInfoOverlay.HideByDisplay();
+    }
+
+    private void InitSearchExpressionInfo()
+    {
+        showSearchExpressionInfoButton.RegisterCallbackButtonTriggered(() => searchExpressionInfoOverlay.ShowByDisplay());
+        closeSearchExpressionInfoButton.RegisterCallbackButtonTriggered(() => HideSearchExpressionInfoOverlay());
     }
 
     private void ShowPlayerSelectContainer()
@@ -933,6 +963,8 @@ public class SongSelectSceneControl : MonoBehaviour, INeedInjection, IBinder, IT
         startButton.text = TranslationManager.GetTranslation(R.Messages.mainScene_button_sing_label);
         scoreModeLabel.text = TranslationManager.GetTranslation(R.Messages.options_scoreMode);
         noSongsFoundLabel.text = TranslationManager.GetTranslation(R.Messages.songSelectScene_noSongsFound);
+        searchExpressionInfoLabel.text = TranslationManager.GetTranslation(R.Messages.songSelectScene_searchExpressionInfo);
+        searchExpressionInfoSyntaxTipsLabel.text = TranslationManager.GetTranslation(R.Messages.songSelectScene_searchExpressionInfo_syntaxTips);
 
         localHighScoreContainer.Q<Label>(R.UxmlNames.title).text = TranslationManager.GetTranslation(R.Messages.songSelectScene_localTopScoresTitle);
         onlineHighScoreContainer.Q<Label>(R.UxmlNames.title).text = TranslationManager.GetTranslation(R.Messages.songSelectScene_onlineTopScoresTitle);

--- a/UltraStar Play/Assets/Scenes/SongSelect/SongSelectSceneInputControl.cs
+++ b/UltraStar Play/Assets/Scenes/SongSelect/SongSelectSceneInputControl.cs
@@ -134,6 +134,10 @@ public class SongSelectSceneInputControl : MonoBehaviour, INeedInjection
         {
             songSelectSceneControl.PlaylistChooserControl.HidePlaylistChooserDropdownOverlay();
         }
+        else if (songSelectSceneControl.IsSearchExpressionInfoOverlayVisible)
+        {
+            songSelectSceneControl.HideSearchExpressionInfoOverlay();
+        }
         else if (songSelectSceneControl.SongSearchControl.IsSearchPropertyDropdownVisible)
         {
             songSelectSceneControl.SongSearchControl.HideSearchPropertyDropdownOverlay();

--- a/UltraStar Play/Assets/Scenes/SongSelect/SongSelectSceneUi.uxml
+++ b/UltraStar Play/Assets/Scenes/SongSelect/SongSelectSceneUi.uxml
@@ -95,7 +95,7 @@
                 </ui:VisualElement>
             </ui:VisualElement>
         </ui:VisualElement>
-        <ui:VisualElement name="playerSelectOverlayContainer" style="width: 100%; height: 100%; position: absolute; align-items: center; justify-content: center; display: flex; background-color: rgba(32, 32, 32, 0.5);">
+        <ui:VisualElement name="playerSelectOverlayContainer" style="width: 100%; height: 100%; position: absolute; align-items: center; justify-content: center; display: none; background-color: rgba(32, 32, 32, 0.5);">
             <ui:VisualElement name="playerSelectOverlay" class="roundCorners focusableNavigatorRoot" style="height: auto; width: 33%; background-color: rgba(32, 32, 32, 0.88); align-items: center; padding-left: 10px; padding-right: 10px; padding-top: 10px; padding-bottom: 10px; display: flex; flex-grow: 2; min-height: 60%;">
                 <ui:VisualElement name="buttonRow" style="flex-direction: row; width: 100%;">
                     <ui:Button text="Back" display-tooltip-when-elided="true" name="closePlayerSelectOverlayButton" style="margin-bottom: 20px; width: auto; flex-grow: 1;" />
@@ -186,7 +186,7 @@
         </ui:VisualElement>
         <ui:VisualElement name="searchPropertyDropdownOverlay" picking-mode="Ignore" class="focusableNavigatorRoot" style="position: absolute; width: 100%; height: 100%; display: none;">
             <ui:Button display-tooltip-when-elided="true" name="closeSearchPropertyDropdownButton" class="transparentBackgroundColor focusableNavigatorIgnore" style="position: absolute; width: 100%; height: 100%;" />
-            <ui:VisualElement name="searchPropertyDropdownContainer" class="roundCorners" style="position: absolute; height: 60%; width: 35%; background-color: rgba(32, 32, 32, 0.88); top: 85px; left: 33%; padding-left: 10px; padding-right: 10px; padding-top: 5px; padding-bottom: 5px;">
+            <ui:VisualElement name="searchPropertyDropdownContainer" class="roundCorners" style="position: absolute; height: 60%; width: 35%; background-color: rgba(32, 32, 32, 0.88); top: 85px; left: 33%; padding-left: 10px; padding-right: 10px; padding-top: 5px; padding-bottom: 5px; flex-direction: column;">
                 <ui:Label text="Search in:" display-tooltip-when-elided="true" name="searchPropertyDropdownTitle" class="smallFont" style="margin-bottom: 5px;" />
                 <ui:ScrollView scroll-deceleration-rate="0,135" elasticity="0,1" name="searchPropertyScrollView" style="flex-grow: 1;">
                     <ui:VisualElement name="artistPropertyContainer" class="searchPropertyContainer" style="flex-direction: row-reverse; align-items: center;">
@@ -217,6 +217,14 @@
                         <ui:Toggle />
                         <ui:Label text="Lyrics" display-tooltip-when-elided="true" style="margin-right: 5px;" />
                     </ui:VisualElement>
+                    <ui:VisualElement name="showSearchExpressionInfoContainer" style="align-items: flex-start;">
+                        <ui:Label text="Advanced search available" display-tooltip-when-elided="true" name="showSearchExpressionInfoTitle" class="smallFont" style="margin-bottom: 5px;" />
+                        <ui:VisualElement style="align-items: auto; width: 100%;">
+                            <ui:Button display-tooltip-when-elided="true" name="showSearchExpressionInfoButton" style="width: auto; height: auto;">
+                                <ui:VisualElement name="helpIcon" picking-mode="Ignore" class="iconImage" style="background-image: url(&apos;project://database/Packages/playshared/Runtime/Graphics/MaterialDesignIcons/help_outline_white_24dp.svg?fileID=7388822144124034973&amp;guid=088f9b8e2490ed44a862efc470dafb60&amp;type=3#help_outline_white_24dp&apos;);" />
+                            </ui:Button>
+                        </ui:VisualElement>
+                    </ui:VisualElement>
                 </ui:ScrollView>
             </ui:VisualElement>
         </ui:VisualElement>
@@ -228,6 +236,17 @@
                     <ui:Button text="Playlist-A" display-tooltip-when-elided="true" style="width: 100%;" />
                     <ui:Button text="Playlist-B" display-tooltip-when-elided="true" style="width: 100%;" />
                 </ui:ScrollView>
+            </ui:VisualElement>
+        </ui:VisualElement>
+        <ui:VisualElement name="searchExpressionInfoOverlay" style="position: absolute; width: 100%; height: 100%; align-items: center; justify-content: center;">
+            <ui:VisualElement name="innerSearchExpressionInfoOverlay" style="position: absolute; background-color: rgba(32, 32, 32, 0.88); border-top-left-radius: 15px; border-bottom-left-radius: 15px; border-top-right-radius: 15px; border-bottom-right-radius: 15px; min-width: 400px; min-height: 300px; padding-left: 10px; padding-right: 10px; padding-top: 10px; padding-bottom: 10px;">
+                <ui:ScrollView scroll-deceleration-rate="0,135" elasticity="0,1" style="flex-grow: 1;">
+                    <ui:Label text="You can use C# expressions to search songs." display-tooltip-when-elided="true" name="searchExpressionInfoLabel" style="margin-bottom: 10px; white-space: normal;" />
+                    <ui:Label text="Note that C# syntax rules apply." display-tooltip-when-elided="true" name="searchExpressionInfoSyntaxTipsLabel" style="white-space: normal;" />
+                </ui:ScrollView>
+                <ui:VisualElement name="buttonRow" style="flex-direction: row; justify-content: flex-end;">
+                    <ui:Button text="Close" display-tooltip-when-elided="true" name="closeSearchExpressionInfoButton" />
+                </ui:VisualElement>
             </ui:VisualElement>
         </ui:VisualElement>
         <ui:Label text="quick-search-text" display-tooltip-when-elided="true" name="fuzzySearchTextLabel" picking-mode="Ignore" style="position: absolute; top: 16px; -unity-text-align: upper-center; width: 100%; display: none;" />

--- a/UltraStar Play/Assets/Scenes/SongSelect/SongSelectSceneUi.uxml
+++ b/UltraStar Play/Assets/Scenes/SongSelect/SongSelectSceneUi.uxml
@@ -27,6 +27,7 @@
                     <ui:Button text="R2 &gt;" display-tooltip-when-elided="true" name="nextCharacterButton" class="transparentBackgroundColor characterQuickJumpCharacterButton focusableNavigatorIgnore" style="width: 25px; height: 100%;" />
                 </ui:VisualElement>
                 <ui:VisualElement name="searchBarContainer" class="outline roundCorners" style="width: 30%; flex-direction: row; height: 100%;">
+                    <ui:VisualElement name="searchErrorIcon" class="iconImage warning" style="position: absolute; background-image: url(&apos;project://database/Packages/playshared/Runtime/Graphics/MaterialDesignIcons/warning_white_24dp.svg?fileID=7388822144124034973&amp;guid=ff7f961fda7782740882d5a7ed473056&amp;type=3#warning_white_24dp&apos;); top: auto; bottom: 100%;" />
                     <ui:TextField picking-mode="Ignore" name="searchTextField" style="align-items: center; height: 100%; flex-grow: 1;">
                         <ui:Label text="Search artist, title, language" display-tooltip-when-elided="true" name="searchTextFieldHint" picking-mode="Ignore" class="smallerFont ellipsis" style="-unity-font-style: italic; width: 85%; position: absolute; left: 10px; color: rgb(0, 0, 0);" />
                     </ui:TextField>
@@ -238,7 +239,7 @@
                 </ui:ScrollView>
             </ui:VisualElement>
         </ui:VisualElement>
-        <ui:VisualElement name="searchExpressionInfoOverlay" style="position: absolute; width: 100%; height: 100%; align-items: center; justify-content: center;">
+        <ui:VisualElement name="searchExpressionInfoOverlay" style="position: absolute; width: 100%; height: 100%; align-items: center; justify-content: center; display: none;">
             <ui:VisualElement name="innerSearchExpressionInfoOverlay" style="position: absolute; background-color: rgba(32, 32, 32, 0.88); border-top-left-radius: 15px; border-bottom-left-radius: 15px; border-top-right-radius: 15px; border-bottom-right-radius: 15px; min-width: 400px; min-height: 300px; padding-left: 10px; padding-right: 10px; padding-top: 10px; padding-bottom: 10px;">
                 <ui:ScrollView scroll-deceleration-rate="0,135" elasticity="0,1" style="flex-grow: 1;">
                     <ui:Label text="You can use C# expressions to search songs." display-tooltip-when-elided="true" name="searchExpressionInfoLabel" style="margin-bottom: 10px; white-space: normal;" />

--- a/UltraStar Play/Packages/playshared/Runtime/Resources/Translations/messages.properties
+++ b/UltraStar Play/Packages/playshared/Runtime/Resources/Translations/messages.properties
@@ -86,6 +86,9 @@ songSelectScene_songMenu_startButton=Sing
 songSelectScene_playlistDropdownTitle=Select playlist:
 songSelectScene_searchPropertyDropdownTitle=Search in:
 
+songSelectScene_searchExpressionInfo=You can use C# expressions to search songs, for example\n• Genre == "Rock"\n• 1990 <= Year && Year <= 1999 and Genre == "Rock"\n• Video != null\n• Title.ToLower().Contains("summer")
+songSelectScene_searchExpressionInfo_syntaxTips=Note that C# syntax rules apply.\n• Uppercase/lowercase is relevant. For example, title.contains("something") must be written as Title.Contains("something").\n• Year = 1990 is an assignment, you need to use Year == 1990.\n• AND is written as &&, OR is written as ||.\n• strings must be quoted.\n• etc.
+
 songProperty_artist=Artist
 songProperty_title=Title
 songProperty_genre=Genre

--- a/UltraStar Play/Packages/playshared/Runtime/Resources/Translations/messages.properties
+++ b/UltraStar Play/Packages/playshared/Runtime/Resources/Translations/messages.properties
@@ -88,6 +88,7 @@ songSelectScene_searchPropertyDropdownTitle=Search in:
 
 songSelectScene_searchExpressionInfo=You can use C# expressions to search songs, for example\n• Genre == "Rock"\n• 1990 <= Year && Year <= 1999 and Genre == "Rock"\n• Video != null\n• Title.ToLower().Contains("summer")
 songSelectScene_searchExpressionInfo_syntaxTips=Note that C# syntax rules apply.\n• Uppercase/lowercase is relevant. For example, title.contains("something") must be written as Title.Contains("something").\n• Year = 1990 is an assignment, you need to use Year == 1990.\n• AND is written as &&, OR is written as ||.\n• strings must be quoted.\n• etc.
+songSelectScene_searchExpressionError=An error occurred with the search expression.\nCheck the syntax and try again.\nError message:\n{errorDetails}
 
 songProperty_artist=Artist
 songProperty_title=Title

--- a/UltraStar Play/Packages/playshared/Runtime/Song/SongMeta.cs
+++ b/UltraStar Play/Packages/playshared/Runtime/Song/SongMeta.cs
@@ -11,34 +11,38 @@ public class SongMeta
     /**
      * Path of the directory of the song's txt file.
      */
-    public string Directory { get; set; }
+    public string Directory { get; set; } = "";
+
     /**
      * File name of the song's txt file (not including any directories).
      */
-    public string Filename { get; set; }
+    public string Filename { get; set; } = "";
+
     /**
      * Hash for the song's txt file, used to uniquely identify it.
      */
-    public string SongHash { get; private set; }
+    public string SongHash { get; private set; } = "";
 
     // required 
     /**
      * Artist of the song.
      */
-    public string Artist { get; set; }
+    public string Artist { get; set; } = "";
     /**
      * The "bars-per-minute" in four-four-time (i.e. (beats-per-minute / 4)) of the song.
      * Example: a BPM value of 60 in a txt file would define a beat every 0.25 seconds (60*4=240 beats-per-minute).
      */
     public float Bpm { get; set; }
+
     /**
      * Path to the audio file.
      */
-    public string Mp3 { get; set; }
+    public string Mp3 { get; set; } = "";
+
     /**
      * Title of the song.
      */
-    public string Title { get; set; }
+    public string Title { get; set; } = "";
 
     // required special fields
     /**
@@ -74,49 +78,60 @@ public class SongMeta
     /**
      * Path to an image file that should be displayed as background when singing.
      */
-    public string Background { get; set; }
+    public string Background { get; set; } = "";
+
     /**
      * Path to an image file that should be displayed as preview in song selection.
      */
-    public string Cover { get; set; }
+    public string Cover { get; set; } = "";
+
     /**
      * Edition of the song, usually either the game it was ripped from or the TV show it was featured in.
      */
-    public string Edition { get; set; }
+    public string Edition { get; set; } = "";
+
     /**
      * Shift in millisecond for the lyrics relative to the audio file.
      */
     public float Gap { get; set; }
+
     /**
      * Genre of the music.
      */
-    public string Genre { get; set; }
+    public string Genre { get; set; } = "";
+
     /**
      * The language of the lyrics.
      */
-    public string Language { get; set; }
+    public string Language { get; set; } = "";
+
     /**
      * Whether the note timestamps are relative to the previous note (true) or to the start of the song (false).
      * Default is false.
      */
     public bool Relative { get; set; }
+
     /**
      * Beat at which a preview of the song should begin.
      * Thus, this beat should start the most memorable part of a song as a preview.
      */
     public float PreviewStart { get; set; }
+
     /**
      * Beat at which the preview should end.
      */
     public float PreviewEnd { get; set; }
+
     /**
      * The video file.
      */
-    public string Video { get; set; }
+    public string Video { get; set; } = "";
+
     /**
      * Delay in seconds for the video playback relative to the audio file.
      */
     public float VideoGap { get; set; }
+
     /**
      * Year in which the song was released.
      */

--- a/UltraStar Play/Packages/playshared/Runtime/StyleSheets/MainStyles.uss
+++ b/UltraStar Play/Packages/playshared/Runtime/StyleSheets/MainStyles.uss
@@ -921,3 +921,12 @@ Label.tinyFont {
     padding-top: 20px;
     padding-bottom: 40px;
 }
+
+.tooltip {
+    font-size: var(--font-size-s);
+    -unity-font-style: bold;
+    padding: 5px;
+    background-color: rgb(60, 63, 65);
+    border-color: rgb(50, 50, 50);
+    border-width: 1px;
+}

--- a/tools/download-dependencies-main-game/download-dependencies-main-game.sh
+++ b/tools/download-dependencies-main-game/download-dependencies-main-game.sh
@@ -6,3 +6,5 @@ sh download-csharpsynthforunity.sh
 sh download-text-mesh-pro-resources.sh
 sh download-sharpziplib.sh
 sh download-serilog.sh
+sh download-jokenizer.sh
+sh download-dynamicqueryable.sh

--- a/tools/download-dependencies-main-game/download-dynamicqueryable.sh
+++ b/tools/download-dependencies-main-game/download-dynamicqueryable.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+old_dir=$(pwd)
+
+cd "../../UltraStar Play/Assets/Plugins"
+echo "Removing old DynamicQueryable folder..."
+rm -rf DynamicQueryable
+mkdir DynamicQueryable
+cd DynamicQueryable
+
+echo "Cloning DynamicQueryable from remote..."
+git init
+git remote add origin https://github.com/umutozel/DynamicQueryable.git
+git config core.sparsecheckout true
+echo "src/DynamicQueryable/*" >> .git/info/sparse-checkout
+git pull --depth=100 origin master
+# Commit from 19 Nov 2020: c4832d4a69127074699b8d4a6c8d897fff644bdb
+git checkout c4832d4a69127074699b8d4a6c8d897fff644bdb
+
+echo "Moving downloaded files to correct position for this project..."
+mv -v src/DynamicQueryable/* ./
+rm -rf ./src
+rm -rf .git
+
+# Remove Properties/AssemblyInfo.cs
+rm -rf Properties
+
+cd "$old_dir"
+echo "Downloading DynamicQueryable done"
+echo ""

--- a/tools/download-dependencies-main-game/download-jokenizer.sh
+++ b/tools/download-dependencies-main-game/download-jokenizer.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+old_dir=$(pwd)
+
+# Jokenizer is a dependency of DynamicQueryable from the same author. Jokenizer is for parsing expressions.
+cd "../../UltraStar Play/Assets/Plugins"
+echo "Removing old Jokenizer.Net folder..."
+rm -rf Jokenizer.Net
+mkdir Jokenizer.Net
+cd Jokenizer.Net
+
+echo "Cloning Jokenizer.Net from remote..."
+git init
+git remote add origin https://github.com/umutozel/Jokenizer.Net.git
+git config core.sparsecheckout true
+echo "src/Jokenizer.Net/*" >> .git/info/sparse-checkout
+git pull --depth=100 origin master
+# Commit from 10 Feb 2020: 8fb6452eea609f5de46911be73d982056080e658
+git checkout 8fb6452eea609f5de46911be73d982056080e658
+
+echo "Moving downloaded files to correct position for this project..."
+mv -v src/Jokenizer.Net/* ./
+rm -rf ./src
+rm -rf .git
+
+# Remove Properties/AssemblyInfo.cs
+rm -rf Properties
+
+cd "$old_dir"
+echo "Downloading Jokenizer.Net done"
+echo ""


### PR DESCRIPTION
### What does this PR do?

Enables to filter the song list via C# expressions as discussed in #325 .
- new lib DynamicQueryable (MIT license) is used to filter songs
    - new lib Jokenizer.Net (MIT license) is a dependency of DynamicQueryable (from the same author).
- A new overlay shows basic info about the search expressions (see messages.properties)
- Errors in search expressions are shown in UI as icon with tooltip above the search TextField
- Initialized SongMeta strings with empty string instead of null. Otherwise the search expressions can run into a NullPointerException (e.g. when doing `Genre.ToLower().Contains("rock")`)

### Closes Issue(s)

close #325 
