### PR TITLE
Anst/fixes

### DIFF
--- a/UltraStar Play/Assets/Common/Audio/AudioManager.cs
+++ b/UltraStar Play/Assets/Common/Audio/AudioManager.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using UnityEngine;
 using UnityEngine.Networking;
 
@@ -28,7 +29,13 @@ public class AudioManager : MonoBehaviour
 
     public AudioClip LoadAudioClipFromFile(string path, bool streamAudio = true)
     {
-        return LoadAudioClipFromUri("file://" + path, streamAudio);
+        if (!File.Exists(path))
+        {
+            Debug.LogError("Audio file does not exist: " + path);
+            return null;
+        }
+
+        return LoadAudioClipFromUri(path, streamAudio);
     }
 
     // When streamAudio is false, all audio data is loaded at once in a blocking way.
@@ -61,12 +68,6 @@ public class AudioManager : MonoBehaviour
 
     private AudioClip LoadAndCacheAudioClip(string uri, bool streamAudio)
     {
-        if (!WebRequestUtils.ResourceExists(uri))
-        {
-            Debug.LogError("Audio file resource does not exist: " + uri);
-            return null;
-        }
-
         AudioClip audioClip = AudioUtils.GetAudioClipUncached(uri, streamAudio);
         if (audioClip == null)
         {

--- a/UltraStar Play/Assets/Common/Audio/SongAudioPlayer/SongAudioPlayer.cs
+++ b/UltraStar Play/Assets/Common/Audio/SongAudioPlayer/SongAudioPlayer.cs
@@ -189,8 +189,14 @@ public class SongAudioPlayer : MonoBehaviour
             return;
         }
 
-        this.SongMeta = songMeta;
         string audioUri = SongMetaUtils.GetAudioUri(songMeta);
+        if (!SongMetaUtils.AudioResourceExists(songMeta))
+        {
+            Debug.Log($"Audio file resource does not exist {songMeta.Mp3}");
+            return;
+        }
+
+        this.SongMeta = songMeta;
         AudioClip audioClip = AudioManager.Instance.LoadAudioClipFromUri(audioUri);
         if (audioClip != null)
         {

--- a/UltraStar Play/Assets/Common/Audio/WavFileWriter.cs
+++ b/UltraStar Play/Assets/Common/Audio/WavFileWriter.cs
@@ -1,0 +1,108 @@
+using System;
+using System.IO;
+using UnityEngine;
+
+// See http://forum.unity3d.com/threads/119295-Writing-AudioListener.GetOutputData-to-wav-problem?p=806734&viewfull=1#post806734
+public static class WavFileWriter
+{
+    private const int HeaderSize = 44;
+    private const int RescaleFactor = 32767;
+    private const int BitsPerSample = 16;
+    private const int BytesPerSample = 2;
+    private const int EmptyByte = new();
+
+    public static void WriteFile(string outputPath, AudioClip clip)
+    {
+        float[] samples = new float[clip.samples];
+        clip.GetData(samples, 0);
+        WriteFile(outputPath, clip.frequency, clip.channels, samples);
+    }
+
+    public static void WriteFile(string outputPath, int frequency, int channels, float[] samples)
+    {
+        if (!outputPath.ToLower().EndsWith(".wav"))
+        {
+            outputPath += ".wav";
+        }
+
+        string directoryPath = Path.GetDirectoryName(outputPath);
+        if (!Directory.Exists(directoryPath))
+        {
+            Directory.CreateDirectory(directoryPath);
+        }
+
+        // The steam will be closed, thanks to the using statement.
+        using FileStream fileStream = CreateEmptyWavFile(outputPath);
+        ConvertAndWrite(fileStream, samples);
+        WriteHeader(fileStream, frequency, channels, samples.Length);
+    }
+
+    private static FileStream CreateEmptyWavFile(string filepath)
+    {
+        FileStream fileStream = new(filepath, FileMode.Create);
+        for (int i = 0; i < HeaderSize; i++)
+        {
+            fileStream.WriteByte(EmptyByte);
+        }
+
+        return fileStream;
+    }
+
+    private static void ConvertAndWrite(FileStream fileStream, float[] samples)
+    {
+        Int16[] intData = new Int16[samples.Length];
+        Byte[] bytesData = new Byte[samples.Length * 2];
+        for (int i = 0; i < samples.Length; i++)
+        {
+            intData[i] = (short)(samples[i] * RescaleFactor);
+            Byte[] byteArray = BitConverter.GetBytes(intData[i]);
+            byteArray.CopyTo(bytesData, i * 2);
+        }
+
+        fileStream.Write(bytesData, 0, bytesData.Length);
+    }
+
+    static void WriteHeader(FileStream fileStream, int frequency, int channels, int sampleCount)
+    {
+        fileStream.Seek(0, SeekOrigin.Begin);
+
+        Byte[] riff = System.Text.Encoding.UTF8.GetBytes("RIFF");
+        fileStream.Write(riff, 0, 4);
+
+        Byte[] chunkSize = BitConverter.GetBytes(fileStream.Length - 8);
+        fileStream.Write(chunkSize, 0, 4);
+
+        Byte[] wave = System.Text.Encoding.UTF8.GetBytes("WAVE");
+        fileStream.Write(wave, 0, 4);
+
+        Byte[] fmt = System.Text.Encoding.UTF8.GetBytes("fmt ");
+        fileStream.Write(fmt, 0, 4);
+
+        Byte[] subChunk1 = BitConverter.GetBytes(16);
+        fileStream.Write(subChunk1, 0, 4);
+
+        Byte[] audioFormat = BitConverter.GetBytes((UInt16) 1);
+        fileStream.Write(audioFormat, 0, 2);
+
+        Byte[] numChannels = BitConverter.GetBytes(channels);
+        fileStream.Write(numChannels, 0, 2);
+
+        Byte[] sampleRate = BitConverter.GetBytes(frequency);
+        fileStream.Write(sampleRate, 0, 4);
+
+        Byte[] byteRate = BitConverter.GetBytes(frequency * channels * BytesPerSample);
+        fileStream.Write(byteRate, 0, 4);
+
+        UInt16 blockAlign = (ushort)(channels * 2);
+        fileStream.Write(BitConverter.GetBytes(blockAlign), 0, 2);
+
+        Byte[] bitsPerSampleByteArray = BitConverter.GetBytes(BitsPerSample);
+        fileStream.Write(bitsPerSampleByteArray, 0, 2);
+
+        Byte[] dataString = System.Text.Encoding.UTF8.GetBytes("data");
+        fileStream.Write(dataString, 0, 4);
+
+        Byte[] subChunk2 = BitConverter.GetBytes(sampleCount * channels * 2);
+        fileStream.Write(subChunk2, 0, 4);
+    }
+}

--- a/UltraStar Play/Assets/Common/Audio/WavFileWriter.cs.meta
+++ b/UltraStar Play/Assets/Common/Audio/WavFileWriter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 61c8c4d2490d4fd7ae7166d7fd234617
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UltraStar Play/Assets/Common/Graphics/ImageManager.cs
+++ b/UltraStar Play/Assets/Common/Graphics/ImageManager.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using UnityEngine;
 using UnityEngine.Networking;
 using UnityEngine.UIElements;
@@ -22,7 +23,13 @@ public static class ImageManager
 
     public static void LoadSpriteFromFile(string path, Action<Sprite> onSuccess, Action<UnityWebRequest> onFailure = null)
     {
-        LoadSpriteFromUri("file://" + path, onSuccess, onFailure);
+        if (!File.Exists(path))
+        {
+            Debug.LogError("Image file does not exist: " + path);
+            return;
+        }
+
+        LoadSpriteFromUri(path, onSuccess, onFailure);
     }
 
     public static void ReloadImage(string uri, UIDocument uiDocument)
@@ -51,12 +58,6 @@ public static class ImageManager
             && cachedSprite.Sprite != null)
         {
             onSuccess(cachedSprite.Sprite);
-            return;
-        }
-
-        if (!WebRequestUtils.ResourceExists(uri))
-        {
-            Debug.LogError("Image resource does not exist: " + uri);
             return;
         }
 

--- a/UltraStar Play/Assets/Common/Model/SettingsManager.cs
+++ b/UltraStar Play/Assets/Common/Model/SettingsManager.cs
@@ -75,7 +75,7 @@ public class SettingsManager : MonoBehaviour
             if (!File.Exists(loadedSettingsPath))
             {
                 UnityEngine.Debug.LogWarning($"Settings file not found. Creating default settings at {loadedSettingsPath}.");
-                settings = new Settings();
+                settings = CreateDefaultSettings();
                 Save();
                 return;
             }
@@ -84,6 +84,24 @@ public class SettingsManager : MonoBehaviour
             nonStaticSettings = settings;
             OverwriteSettingsWithCommandLineArguments();
         }
+    }
+
+    private Settings CreateDefaultSettings()
+    {
+        Settings defaultSettings = new Settings();
+#if UNITY_ANDROID
+        if (!Application.isEditor)
+        {
+            // Create internal song folder on Android and add it to the settings.
+            string internalSongFolder = AndroidUtils.GetAppSpecificStorageAbsolutePath(false) + "/Songs";
+            if (!Directory.Exists(internalSongFolder))
+            {
+                Directory.CreateDirectory(internalSongFolder);
+            }
+            defaultSettings.GameSettings.songDirs.Add(internalSongFolder);
+        }
+#endif
+        return defaultSettings;
     }
 
     private void OverwriteSettingsWithCommandLineArguments()

--- a/UltraStar Play/Assets/Common/Video/SongVideoPlayer/SongVideoPlayer.cs
+++ b/UltraStar Play/Assets/Common/Video/SongVideoPlayer/SongVideoPlayer.cs
@@ -5,6 +5,7 @@ using UniRx;
 using UnityEngine;
 using UnityEngine.UIElements;
 using UnityEngine.Video;
+using UnityEngine.Windows;
 
 public class SongVideoPlayer : MonoBehaviour, INeedInjection, IInjectionFinishedListener
 {
@@ -145,12 +146,6 @@ public class SongVideoPlayer : MonoBehaviour, INeedInjection, IInjectionFinished
 
     private void LoadVideo(string uri)
     {
-        if (!WebRequestUtils.ResourceExists(uri))
-        {
-            Debug.LogWarning("Video file resource does not exist: " + uri);
-            return;
-        }
-
         videoPlayer.url = GetVideoPlayerUri(uri);
         // The url is empty if loading the video failed.
         HasLoadedVideo = !string.IsNullOrEmpty(videoPlayer.url);
@@ -269,17 +264,18 @@ public class SongVideoPlayer : MonoBehaviour, INeedInjection, IInjectionFinished
         {
             videoImageVisualElement.HideByDisplay();
         }
-        if (string.IsNullOrEmpty(SongMeta.Background))
+        if (SongMeta.Background.IsNullOrEmpty())
         {
             ShowCoverImageAsBackground();
             return;
         }
 
         string backgroundUri = SongMetaUtils.GetBackgroundUri(SongMeta);
-        if (!WebRequestUtils.ResourceExists(backgroundUri))
+        if (!SongMetaUtils.BackgroundResourceExists(songMeta))
         {
             Debug.LogWarning("Showing cover image because background image resource does not exist: " + backgroundUri);
             ShowCoverImageAsBackground();
+            return;
         }
 
         LoadBackgroundImage(backgroundUri);
@@ -293,7 +289,7 @@ public class SongVideoPlayer : MonoBehaviour, INeedInjection, IInjectionFinished
             return;
         }
 
-        if (!WebRequestUtils.ResourceExists(coverUri))
+        if (!SongMetaUtils.CoverResourceExists(SongMeta))
         {
             Debug.LogWarning("Cover image resource does not exist: " + coverUri);
             return;
@@ -337,7 +333,14 @@ public class SongVideoPlayer : MonoBehaviour, INeedInjection, IInjectionFinished
             return;
         }
 
-        LoadVideo(SongMetaUtils.GetVideoUri(initSongMeta));
+        string videoUri = SongMetaUtils.GetVideoUri(initSongMeta);
+        if (!SongMetaUtils.VideoResourceExists(initSongMeta))
+        {
+            Debug.LogWarning("Video file resource does not exist: " + videoUri);
+            return;
+        }
+
+        LoadVideo(videoUri);
     }
 
     void OnEnable()

--- a/UltraStar Play/Assets/Editor/Tests/PitchDetectionTests.cs
+++ b/UltraStar Play/Assets/Editor/Tests/PitchDetectionTests.cs
@@ -34,7 +34,7 @@ public class PitchDetectionTests
         foreach (KeyValuePair<string, string> pathAndNoteName in pathToExpectedMidiNoteNameMap)
         {
             // Load the audio clip
-            string uri = "file://" + pathAndNoteName.Key;
+            string uri = pathAndNoteName.Key;
             AudioClip audioClip = AudioUtils.GetAudioClipUncached(uri, false);
             float[] samples = new float[audioClip.samples];
             audioClip.GetData(samples, 0);

--- a/UltraStar Play/Assets/Scenes/Main/MainSceneUi.uxml
+++ b/UltraStar Play/Assets/Scenes/Main/MainSceneUi.uxml
@@ -21,9 +21,10 @@
             <ui:VisualElement name="buttonRow" style="flex-direction: row; width: 100%; justify-content: center; align-items: center;">
                 <ui:Button text="Create Song" name="createSongButton" class="mainSceneButton" />
                 <ui:VisualElement name="space" class="mainSceneButtonSpacer" />
-                <ui:Button text="Settings" name="settingsButton" class="mainSceneButton">
+                <ui:VisualElement name="settingsButtonContainer" style="background-color: rgba(0, 0, 0, 0);">
+                    <ui:Button text="Settings" name="settingsButton" class="mainSceneButton" />
                     <MaterialIcon name="settingsProblemHintIcon" icon="warning" class="settingsProblemHintIcon warning rounded" />
-                </ui:Button>
+                </ui:VisualElement>
                 <ui:VisualElement name="space" class="mainSceneButtonSpacer" />
                 <ui:Button text="Quit" name="quitButton" class="mainSceneButton mainSceneExitButton" style="display: flex;" />
                 <ui:VisualElement style="position: absolute; right: 5px;" />

--- a/UltraStar Play/Assets/Scenes/Options/OptionsOverview/OptionsOverviewSceneUi.uxml
+++ b/UltraStar Play/Assets/Scenes/Options/OptionsOverview/OptionsOverviewSceneUi.uxml
@@ -20,11 +20,13 @@
                         <MaterialIcon icon="sports_esports" name="image" />
                         <ui:Label text="Game" name="label" />
                     </ui:Button>
-                    <ui:Button name="songsOptionsButton" class="optionsOverviewButton">
-                        <MaterialIcon icon="music_note" name="image" />
-                        <ui:Label text="Songs" name="label" />
+                    <ui:VisualElement name="songOptionsButtonContainer" style="background-color: rgba(0, 0, 0, 0);">
+                        <ui:Button name="songsOptionsButton" class="optionsOverviewButton">
+                            <MaterialIcon icon="music_note" name="image" />
+                            <ui:Label text="Songs" name="label" />
+                        </ui:Button>
                         <MaterialIcon name="songSettingsProblemHintIcon" icon="warning" class="rounded warning settingsProblemHintIcon" />
-                    </ui:Button>
+                    </ui:VisualElement>
                     <ui:Button name="graphicsOptionsButton" class="optionsOverviewButton">
                         <MaterialIcon icon="desktop_windows" name="image" />
                         <ui:Label text="Graphics" name="label" />
@@ -35,16 +37,20 @@
                     </ui:Button>
                 </ui:VisualElement>
                 <ui:VisualElement name="buttonContainer" class="optionsOverviewButtonRow">
-                    <ui:Button name="recordingOptionsButton" class="optionsOverviewButton">
-                        <MaterialIcon icon="mic" name="image" />
-                        <ui:Label text="Recording" name="label" />
+                    <ui:VisualElement name="recordingOptionsButtonContainer" style="background-color: rgba(0, 0, 0, 0);">
+                        <ui:Button name="recordingOptionsButton" class="optionsOverviewButton">
+                            <MaterialIcon icon="mic" name="image" />
+                            <ui:Label text="Recording" name="label" />
+                        </ui:Button>
                         <MaterialIcon name="recordingSettingsProblemHintIcon" icon="warning" class="rounded warning settingsProblemHintIcon" />
-                    </ui:Button>
-                    <ui:Button name="profileOptionsButton" class="optionsOverviewButton">
-                        <MaterialIcon icon="people" name="image" />
-                        <ui:Label text="Players" name="label" />
+                    </ui:VisualElement>
+                    <ui:VisualElement name="profileOptionsButtonContainer" style="background-color: rgba(0, 0, 0, 0);">
+                        <ui:Button name="profileOptionsButton" class="optionsOverviewButton">
+                            <MaterialIcon icon="people" name="image" />
+                            <ui:Label text="Players" name="label" />
+                        </ui:Button>
                         <MaterialIcon name="playerProfileSettingsProblemHintIcon" icon="warning" class="rounded warning settingsProblemHintIcon" />
-                    </ui:Button>
+                    </ui:VisualElement>
                     <ui:Button name="designOptionsButton" class="optionsOverviewButton">
                         <MaterialIcon icon="filter_b_and_w" name="image" />
                         <ui:Label text="Design" name="label" />

--- a/UltraStar Play/Assets/Scenes/SongEditor/Actions/MergeNotesAction.cs
+++ b/UltraStar Play/Assets/Scenes/SongEditor/Actions/MergeNotesAction.cs
@@ -14,6 +14,9 @@ public class MergeNotesAction : INeedInjection
     [Inject]
     private SongMetaChangeEventStream songMetaChangeEventStream;
 
+    [Inject]
+    private SongEditorLayerManager layerManager;
+
     public bool CanExecute(IReadOnlyCollection<Note> selectedNotes)
     {
         return selectedNotes.Count > 1;
@@ -35,6 +38,11 @@ public class MergeNotesAction : INeedInjection
         }
         Note mergedNote = new(targetNote.Type, minBeat, maxBeat - minBeat, targetNote.TxtPitch, stringBuilder.ToString());
         mergedNote.SetSentence(targetNote.Sentence);
+
+        if (layerManager.TryGetLayer(targetNote, out SongEditorLayer songEditorLayer))
+        {
+            layerManager.AddNoteToLayer(songEditorLayer.LayerEnum, mergedNote);
+        }
 
         // Remove old notes
         deleteNotesAction.Execute(sortedNotes);

--- a/UltraStar Play/Assets/Scenes/SongEditor/Actions/MoveNotesToOtherVoiceAction.cs
+++ b/UltraStar Play/Assets/Scenes/SongEditor/Actions/MoveNotesToOtherVoiceAction.cs
@@ -126,6 +126,7 @@ public class MoveNotesToOtherVoiceAction : INeedInjection
             return false;
         }
         return note.Sentence != null
+               && note.Sentence.Voice != null
                && voiceNames.AnyMatch(voiceName => note.Sentence.Voice.VoiceNameEquals(voiceName));
     }
 

--- a/UltraStar Play/Assets/Scenes/SongEditor/Actions/SplitNotesAction.cs
+++ b/UltraStar Play/Assets/Scenes/SongEditor/Actions/SplitNotesAction.cs
@@ -9,6 +9,9 @@ public class SplitNotesAction : INeedInjection
     [Inject]
     private SongMetaChangeEventStream songMetaChangeEventStream;
 
+    [Inject]
+    private SongEditorLayerManager layerManager;
+
     public bool CanExecute(IReadOnlyCollection<Note> selectedNotes)
     {
         return selectedNotes.AnyMatch(it => it.Length > 1);
@@ -35,6 +38,12 @@ public class SplitNotesAction : INeedInjection
                 int splitBeat = note.StartBeat + (note.Length / 2);
                 Note newNote = new(note.Type, splitBeat, note.EndBeat - splitBeat, note.TxtPitch, newNoteText);
                 newNote.SetSentence(note.Sentence);
+
+                if (layerManager.TryGetLayer(note, out SongEditorLayer songEditorLayer))
+                {
+                    layerManager.AddNoteToLayer(songEditorLayer.LayerEnum, newNote);
+                }
+
                 note.SetEndBeat(splitBeat);
             }
         }

--- a/UltraStar Play/Assets/Scenes/SongEditor/EditorNote/EditorNoteControl.cs
+++ b/UltraStar Play/Assets/Scenes/SongEditor/EditorNote/EditorNoteControl.cs
@@ -111,6 +111,7 @@ public class EditorNoteControl : INeedInjection, IInjectionFinishedListener
             .WithRootVisualElement(VisualElement)
             .WithBindingForInstance(this)
             .CreateAndInject<EditorNoteContextMenuControl>();
+        disposables.Add(contextMenuControl);
 
         SyncWithNote();
     }

--- a/UltraStar Play/Assets/Scenes/SongEditor/OverviewBar/OverviewAreaControl.cs
+++ b/UltraStar Play/Assets/Scenes/SongEditor/OverviewBar/OverviewAreaControl.cs
@@ -85,8 +85,15 @@ public class OverviewAreaControl : IInjectionFinishedListener
 
         using (new DisposableStopwatch($"Created audio waveform in <millis> ms"))
         {
+            string audioUri = SongMetaUtils.GetAudioUri(songMeta);
+            if (!SongMetaUtils.AudioResourceExists(songMeta))
+            {
+                Debug.Log($"Audio file resource does not exist {audioUri}");
+                return;
+            }
+
             // For drawing the waveform, the AudioClip must not be streamed. All data must have been fully loaded.
-            AudioClip audioClip = audioManager.LoadAudioClipFromUri(SongMetaUtils.GetAudioUri(songMeta), false);
+            AudioClip audioClip = audioManager.LoadAudioClipFromUri(audioUri, false);
             audioWaveFormVisualization.DrawWaveFormMinAndMaxValues(audioClip);
         }
     }

--- a/UltraStar Play/Assets/Scenes/SongSelect/SongRoulette/SongEntryControl.cs
+++ b/UltraStar Play/Assets/Scenes/SongSelect/SongRoulette/SongEntryControl.cs
@@ -233,12 +233,6 @@ public class SongEntryControl : INeedInjection, IDragListener<GeneralDragEvent>,
             }
         }
 
-        if (!WebRequestUtils.ResourceExists(coverUri))
-        {
-            Debug.Log("Cover image resource does not exist: " + coverUri);
-            return;
-        }
-
         ImageManager.LoadSpriteFromUri(coverUri, loadedSprite =>
         {
             songImageOuter.style.backgroundImage = new StyleBackground(loadedSprite);

--- a/UltraStar Play/Assets/Scenes/SongSelect/SongSelectSceneControl.cs
+++ b/UltraStar Play/Assets/Scenes/SongSelect/SongSelectSceneControl.cs
@@ -744,7 +744,7 @@ public class SongSelectSceneControl : MonoBehaviour, INeedInjection, IBinder, IT
             if (!WebRequestUtils.IsHttpOrHttpsUri(SelectedSong.Mp3))
             {
                 string audioUri = SongMetaUtils.GetAudioUri(SelectedSong);
-                if (!WebRequestUtils.ResourceExists(audioUri))
+                if (!SongMetaUtils.AudioResourceExists(SelectedSong))
                 {
                     string message = "Audio file resource does not exist: " + audioUri;
                     Debug.Log(message);

--- a/UltraStar Play/Packages/playshared/Runtime/Song/SongMetaUtils.cs
+++ b/UltraStar Play/Packages/playshared/Runtime/Song/SongMetaUtils.cs
@@ -6,6 +6,26 @@ using UnityEngine;
 
 public static class SongMetaUtils
 {
+    public static bool CoverResourceExists(SongMeta songMeta)
+    {
+        return ResourceExists(songMeta, songMeta.Cover);
+    }
+
+    public static bool BackgroundResourceExists(SongMeta songMeta)
+    {
+        return ResourceExists(songMeta, songMeta.Background);
+    }
+
+    public static bool VideoResourceExists(SongMeta songMeta)
+    {
+        return ResourceExists(songMeta, songMeta.Video);
+    }
+
+    public static bool AudioResourceExists(SongMeta songMeta)
+    {
+        return ResourceExists(songMeta, songMeta.Mp3);
+    }
+
     public static string GetCoverUri(SongMeta songMeta)
     {
         return GetUri(songMeta, songMeta.Cover);
@@ -26,6 +46,23 @@ public static class SongMetaUtils
         return GetUri(songMeta, songMeta.Mp3);
     }
 
+    /**
+     * Checks if a file exists.
+     * Assumes that the resource behind a http and https URI exists (always returns true for these URIs).
+     */
+    private static bool ResourceExists(SongMeta songMeta, string pathOrUri)
+    {
+        if (WebRequestUtils.IsHttpOrHttpsUri(pathOrUri))
+        {
+            return true;
+        }
+
+        return File.Exists(GetUri(songMeta, pathOrUri));
+    }
+
+    /**
+     * Returns the URI or absolute file system path to a resource.
+     */
     private static string GetUri(SongMeta songMeta, string pathOrUri)
     {
         if (pathOrUri.IsNullOrEmpty())
@@ -38,7 +75,8 @@ public static class SongMetaUtils
             return pathOrUri;
         }
 
-        return "file://" + songMeta.Directory + Path.DirectorySeparatorChar + pathOrUri;
+        // The given path is relative to the song file. Make it absolute.
+        return songMeta.Directory + Path.DirectorySeparatorChar + pathOrUri;
     }
 
     public static string GetAbsoluteSongMetaPath(SongMeta songMeta)
@@ -267,9 +305,9 @@ public static class SongMetaUtils
                 // Do not attempt to load the video file
                 songMeta.Video = "";
             }
-            else if (!WebRequestUtils.ResourceExists(SongMetaUtils.GetVideoUri(songMeta)))
+            else if (!VideoResourceExists(songMeta))
             {
-                songIssues.Add(SongIssue.CreateWarning(songMeta, "Video file resource does not exist: " + SongMetaUtils.GetVideoUri(songMeta)));
+                songIssues.Add(SongIssue.CreateWarning(songMeta, "Video file resource does not exist: " + GetVideoUri(songMeta)));
                 // Do not attempt to load the video file
                 songMeta.Video = "";
             }
@@ -281,9 +319,9 @@ public static class SongMetaUtils
         {
             songIssues.Add(SongIssue.CreateError(songMeta, "Unsupported audio format: " + Path.GetExtension(songMeta.Mp3)));
         }
-        else if (!WebRequestUtils.ResourceExists(SongMetaUtils.GetAudioUri(songMeta)))
+        else if (!AudioResourceExists(songMeta))
         {
-            songIssues.Add(SongIssue.CreateError(songMeta, "Audio file resource does not exist: " + SongMetaUtils.GetAudioUri(songMeta)));
+            songIssues.Add(SongIssue.CreateError(songMeta, "Audio file resource does not exist: " + GetAudioUri(songMeta)));
         }
 
         // Log found issues

--- a/UltraStar Play/Packages/playshared/Runtime/Song/SongMetaUtils.cs
+++ b/UltraStar Play/Packages/playshared/Runtime/Song/SongMetaUtils.cs
@@ -57,7 +57,7 @@ public static class SongMetaUtils
             return true;
         }
 
-        return File.Exists(GetUri(songMeta, pathOrUri));
+        return File.Exists(GetAbsoluteFilePath(songMeta, pathOrUri));
     }
 
     /**
@@ -76,7 +76,13 @@ public static class SongMetaUtils
         }
 
         // The given path is relative to the song file. Make it absolute.
-        return songMeta.Directory + Path.DirectorySeparatorChar + pathOrUri;
+        string absoluteFilePath = GetAbsoluteFilePath(songMeta, pathOrUri);
+        return WebRequestUtils.AbsoluteFilePathToUri(absoluteFilePath);
+    }
+
+    private static string GetAbsoluteFilePath(SongMeta songMeta, string path)
+    {
+        return songMeta.Directory + Path.DirectorySeparatorChar + path;
     }
 
     public static string GetAbsoluteSongMetaPath(SongMeta songMeta)

--- a/UltraStar Play/Packages/playshared/Runtime/UI/ContextMenu/ContextMenuControl.cs
+++ b/UltraStar Play/Packages/playshared/Runtime/UI/ContextMenu/ContextMenuControl.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using PrimeInputActions;
 using UniInject;
 using UniRx;
@@ -7,7 +8,7 @@ using UnityEngine.InputSystem;
 using UnityEngine.UIElements;
 using Touch = UnityEngine.InputSystem.EnhancedTouch.Touch;
 
-public class ContextMenuControl : INeedInjection, IInjectionFinishedListener
+public class ContextMenuControl : INeedInjection, IInjectionFinishedListener, IDisposable
 {
     private static readonly Vector2 popupOffset = new(2, 2);
 
@@ -31,6 +32,8 @@ public class ContextMenuControl : INeedInjection, IInjectionFinishedListener
     private bool isPointerDown;
     private Vector2 pointerDownPosition;
 
+    private List<IDisposable> disposables = new();
+
     public virtual void OnInjectionFinished()
     {
         panelHelper = new PanelHelper(uiDocument);
@@ -38,9 +41,9 @@ public class ContextMenuControl : INeedInjection, IInjectionFinishedListener
         uiDocument.rootVisualElement.RegisterCallback<PointerMoveEvent>(evt => OnPointerMove(evt), TrickleDown.TrickleDown);
         uiDocument.rootVisualElement.RegisterCallback<PointerUpEvent>(evt => OnPointerUp(), TrickleDown.TrickleDown);
 
-        InputManager.GetInputAction("usplay/openContextMenu").PerformedAsObservable()
+        disposables.Add(InputManager.GetInputAction("usplay/openContextMenu").PerformedAsObservable()
             .Subscribe(CheckOpenContextMenuFromInputAction)
-            .AddTo(gameObject);
+            .AddTo(gameObject));
     }
 
     private void OnPointerDown(IPointerEvent evt)
@@ -85,7 +88,7 @@ public class ContextMenuControl : INeedInjection, IInjectionFinishedListener
         {
             return;
         }
-
+        Debug.Log($"OpenContextMenu {GetType().Name} {Time.frameCount}");
         OpenContextMenu(pointerPosition + popupOffset);
     }
 
@@ -99,5 +102,10 @@ public class ContextMenuControl : INeedInjection, IInjectionFinishedListener
         ContextMenuPopupControl contextMenuPopup = new(gameObject, position);
         injector.Inject(contextMenuPopup);
         FillContextMenuAction(contextMenuPopup);
+    }
+
+    public void Dispose()
+    {
+        disposables.ForEach(disposable => disposable.Dispose());
     }
 }

--- a/UltraStar Play/Packages/playshared/Runtime/Util/NumberUtils.cs
+++ b/UltraStar Play/Packages/playshared/Runtime/Util/NumberUtils.cs
@@ -43,12 +43,12 @@ public static class NumberUtils
         return result;
     }
 
-    public static double Median(IEnumerable<double> enumerable)
+    public static T Median<T>(IEnumerable<T> enumerable)
     {
-        List<double> list = enumerable.ToList();
+        List<T> list = enumerable.ToList();
         if (list.IsNullOrEmpty())
         {
-            return 0;
+            return default(T);
         }
 
         list.Sort();

--- a/UltraStar Play/Packages/playshared/Runtime/Util/WebRequestUtils.cs
+++ b/UltraStar Play/Packages/playshared/Runtime/Util/WebRequestUtils.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections;
-using System.IO;
 using UnityEngine;
 using UnityEngine.Networking;
 
@@ -42,5 +41,35 @@ public static class WebRequestUtils
         return !uri.IsNullOrEmpty()
                 && (uri.StartsWith("http://")
                     || uri.StartsWith("https://"));
+    }
+
+    public static bool IsNetworkPath(string absolutePath)
+    {
+        return !absolutePath.IsNullOrEmpty()
+               && (absolutePath.StartsWith(@"\\")
+                   || absolutePath.StartsWith("//"));
+    }
+
+    public static string AbsoluteFilePathToUri(string absolutePath)
+    {
+        string uri;
+        if (absolutePath.StartsWith(@"\\"))
+        {
+            // This is a Windows-like network path.
+            // MUST prefix it with the file:// scheme AND an additional slash for Unity API to work.
+            // See https://forum.unity.com/threads/unitywebrequest-and-local-area-network.714353/
+            return "file:///" + absolutePath;
+        }
+
+        if (absolutePath.StartsWith("//"))
+        {
+            // This also is a Unix-like network path. But because forward slashes are used, MUST prefix it with the file:// scheme ONLY for Unity API to work.
+            return "file://" + absolutePath;
+        }
+
+        // This is a local path. MUST NOT prefix it with the file:// scheme.
+        // Otherwise some paths may not work, e.g., when it contains a space AND a plus character.
+        // See https://forum.unity.com/threads/unitywebrequest-file-protocol-not-working-with-plus-character-in-path-how-to-escape-the-uri.1364499/#post-8655012
+        return absolutePath;
     }
 }


### PR DESCRIPTION
### What does this PR do?

Small PR with some fixes
- load audio / image files from path with space and plus character (#339)
    - Solution: pass System.Uri object to Unity API instead of string with `file://` prefix.
    - Instead of `WebRequestUtils.ResourceExists` there are now methods in `SongMetaUtils` because this class knows whether it is a file path.
- load songs from network folder
    - Song folders such as `\\192.168.2.34\Users\foobar\NetTest` now work, at least on Windows
    - This was fiddly. Unity requires the URI depending on path and whether forward or backward slashes are used.
    - Tested on Windows with Windows shared folder.
    - Probably works also on other desktop platforms but I did not test this
    - Sadly, does not work on Android.
        - On Windows the OS is handling all network file system details. One can just use `System.IO.File.Exists` as usual.
        - On Android however, this does not work.
        - Maybe it is possible to manually mount the shared network folder to a local folder that can then be accessed by UltraStar Play. But I did not test this because I think mounting requires a rooted device.
- tooltips are shown on pointer down (includes touch)
    - useful on touch devices because there is no mouse pointer
    - Therefor, had to rearrange the UXML layout a little bit

**Song editor fixes**
- fix split and merge notes of layer
- fix ContextMenuControl was not disposed
- added WavFileWriter to debug audio samples

### Closes Issue(s)

close #339
close #347
