### PR TITLE
Anst/unity 2022.2.1

### DIFF
--- a/.github/workflows/build-companion-app.yml
+++ b/.github/workflows/build-companion-app.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         unityVersion:
-          - 2021.3.4f1
+          - 2022.2.1f1
         targetPlatform:
           # - StandaloneWindows64
           # - StandaloneLinux64

--- a/.github/workflows/build-main-game.yml
+++ b/.github/workflows/build-main-game.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         unityVersion:
-          - 2021.3.4f1
+          - 2022.2.1f1
         targetPlatform:
           - StandaloneWindows64
           - StandaloneLinux64

--- a/.github/workflows/test-companion-app.yml
+++ b/.github/workflows/test-companion-app.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         unityVersion:
-          - 2021.3.4f1
+          - 2022.2.1f1
         targetPlatform:
           - Android
           - iOS

--- a/.github/workflows/test-main-game.yml
+++ b/.github/workflows/test-main-game.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         unityVersion:
-          - 2021.3.4f1
+          - 2022.2.1f1
         targetPlatform:
           # At the moment, tests are target platform independent. Thus only build one.
           - StandaloneLinux64

--- a/UltraStar Play/Packages/packages-lock.json
+++ b/UltraStar Play/Packages/packages-lock.json
@@ -117,7 +117,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.services.core": {
-      "version": "1.5.2",
+      "version": "1.6.0",
       "depth": 1,
       "source": "registry",
       "dependencies": {

--- a/UltraStar Play/ProjectSettings/ProjectVersion.txt
+++ b/UltraStar Play/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2023.1.0a18
-m_EditorVersionWithRevision: 2023.1.0a18 (14fa785aa82f)
+m_EditorVersion: 2022.2.1f1
+m_EditorVersionWithRevision: 2022.2.1f1 (4fead5835099)


### PR DESCRIPTION
### What does this PR do?

Downgrade to Unity 2022.2.1.
Previously an alpha version of Unity (2023.1.0a18) was used, which had other issues.
