### PR TITLE
Change saved song file encoding to UTF-8 without BOM

### DIFF
--- a/UltraStar Play/Packages/playshared/Runtime/Song/UltraStarSongFileWriter.cs
+++ b/UltraStar Play/Packages/playshared/Runtime/Song/UltraStarSongFileWriter.cs
@@ -9,7 +9,8 @@ public static class UltraStarSongFileWriter
     public static void WriteFile(string absolutePath, SongMeta songMeta)
     {
         string txtFileContent = GetTxtFileContent(songMeta);
-        File.WriteAllText(absolutePath, txtFileContent, Encoding.UTF8);
+        // Do not use Encoding.UTF8 as it will produce a BOM.
+        File.WriteAllText(absolutePath, txtFileContent, new UTF8Encoding());
     }
 
     private static string GetTxtFileContent(SongMeta songMeta)


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://github.com/UltraStar-Deluxe/Play/blob/master/CONTRIBUTING.md.

-->

### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->

Currently Ultrastar Play song editor saves all song files as UTF-8 with BOM. This happens because in code the encoding is `System.Text.Encoding.UTF8`, which produces a BOM according to [documentation](https://learn.microsoft.com/en-us/dotnet/api/system.text.utf8encoding?view=net-8.0#remarks).

This PR changes the encoding for saved song files to UTF-8 without BOM.

### Closes Issue(s)

<!-- List here all the issues closed by this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->

The [Ultrastar format specification](https://usdx.eu/format/) was [recently updated](https://github.com/UltraStar-Deluxe/format/pull/45). It now specifies that all song files should use UTF-8 without BOM as their encoding. There are also tools in the Ultrastar ecosystem, such as Performous Composer, that fail to open song files with BOM.

There is some discussion about UTF-8 BOMs in this Ultrastar format issue https://github.com/UltraStar-Deluxe/format/issues/42

### More

### Additional Notes

<!-- Anything else we should know when reviewing? -->

I have not tested this code. The change seems trivial enough that I'm confident it would work.