### PR TITLE
GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -18,18 +18,25 @@ Tell us what happens
 Tell us what should actually happen
 
 ### Steps to reproduce
-Please supply step-by-step instructions so that anyone with the same environment can reproduce the issue. Whenever you offer a description, imagine
-yourself in the shoes of someone who has never encountered this problem before and would like to know exactly how to observe it under a given set of conditions.
+- Reproducible (mark with x): [ ] always, [ ] sometimes
+
+Please provide detailed step-by-step instructions to help us understand and replicate the issue you encountered.
+Try to use as few steps as possible after starting the game. Clear and concise instructions will make sure that the issue can be addressed promptly.
+
 Here is an example:
 
-1. Open the ultrastarplay.exe
+1. Navigate to the song selection menu
 2. Click on button X, then on the menu that appears, click Y
 3. Wait for 3 seconds, and note the appearance of an unexpected message
 
-
 ### Details
-Provide some additional information:
+Please provide additional information.
 
-- UltraStar Play version:
-- Operating System + version
-- if applicable, add a log file
+- Game version: 
+- Operating System and version: 
+- Song details, if applicable (e.g. audio and video file format): 
+- Attach screenshots and screen recordings
+- Attach a log file. To find the log file, see https://melodymania.org/how-to-report-issues
+
+### Implementation hints
+Information on how the expected behavior could be achieved (optional).

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -12,9 +12,10 @@ For support questions, please use our Discord: https://discord.gg/PAUJFKCGbb
 -->
 
 ### Actual behaviour
-
-Tell us what happens
+Tell us what happens.
 
 ### Expected behaviour
+Tell us what should actually happen.
 
-Tell us what should actually happen
+### Implementation hints
+Information on how the expected behavior could be achieved (optional).


### PR DESCRIPTION
### What does this PR do?

Minor adjustments to the GitHub issue templates, notably the bug report.

- I found that often a log file and details about the song file format are useful. This is why I explicitly added bullet points for these.
- The checkbox for "reproducible" implies that the user should try to reproduce the issue.
- The idea behind the section for "implementation hints" is to separate the actual issue and potential solutions. I found that sometimes people try to come up with a solution first, thereby skipping the formulation of the initial problem.