### PR TITLE
Change SongSearch behaviour

### DIFF
--- a/UltraStar Play/Assets/Scenes/SongSelect/Search/SongSearchControl.cs
+++ b/UltraStar Play/Assets/Scenes/SongSelect/Search/SongSearchControl.cs
@@ -262,11 +262,15 @@ public class SongSearchControl : INeedInjection, IInjectionFinishedListener
         string searchText = GetRawSearchText() != "#"
             ? GetSearchText()
             : "";
-        string[] searchTexts = searchText.Split(new char[0], StringSplitOptions.RemoveEmptyEntries);
-        List<SongMeta> filteredSongs = songMetas;
-        for (string searchWord in searchTexts) {
-            filteredSongs = filteredSongs.Where(songMeta => SongMetaMatchesSearchedProperties(songMeta, searchWord)).ToList();
+        if (searchText.IsNullOrEmpty()) {
+            return songMetas;
         }
+        // Split searchText at whitespaces and match each word individually
+        string[] searchTexts = searchText.Split(new char[0], StringSplitOptions.RemoveEmptyEntries);
+        List<SongMeta> filteredSongs = songMetas
+            .Where(songMeta => searchTexts.IsNullOrEmpty()
+                               || searchTexts.AllMatch(searchWord => SongMetaMatchesSearchedProperties(songMeta, searchWord)))
+            .ToList();
         return filteredSongs;
     }
 

--- a/UltraStar Play/Assets/Scenes/SongSelect/Search/SongSearchControl.cs
+++ b/UltraStar Play/Assets/Scenes/SongSelect/Search/SongSearchControl.cs
@@ -262,10 +262,11 @@ public class SongSearchControl : INeedInjection, IInjectionFinishedListener
         string searchText = GetRawSearchText() != "#"
             ? GetSearchText()
             : "";
-        List<SongMeta> filteredSongs = songMetas
-            .Where(songMeta => searchText.IsNullOrEmpty()
-                               || SongMetaMatchesSearchedProperties(songMeta, searchText))
-            .ToList();
+        string[] searchTexts = searchText.Split(new char[0], StringSplitOptions.RemoveEmptyEntries);
+        List<SongMeta> filteredSongs = songMetas;
+        for (string searchWord in searchTexts) {
+            filteredSongs = filteredSongs.Where(songMeta => SongMetaMatchesSearchedProperties(songMeta, searchWord)).ToList();
+        }
         return filteredSongs;
     }
 


### PR DESCRIPTION
### What does this PR do?

Change SongSearch to search based on all individual words in the SearchText instead of the literal SearchString

### Motivation

The SongSearch currently searches for the whole string as given. This causes problems and confusions when using to many whitespaces ("ABBA " or "Imagine  Dragons" with two spaces would not find anything) and it makes it difficult to search for artist and title at the same time ("Queen Bohemian" does not find anything). I have seen a lot of people confused about both of these problems.

The more intuitive behaviour would be to split the search string at all whitespaces and to search for each part individually. This small edit should create this behaviour.

### Additional Notes

One could also add a small button to switch between the two search variants, but I think the proposed variant would almost always be preferred.
 (I did not test the changes because I did not want to set up everything for this tiny commit. So I don't know if StringSplitOptions needs to be imported or something)

