### PR TITLE
Fix extra end of phrase after the last note

### DIFF
--- a/UltraStar Play/Assets/Editor/Tests/UltraStarSongFormatTest.cs
+++ b/UltraStar Play/Assets/Editor/Tests/UltraStarSongFormatTest.cs
@@ -39,6 +39,15 @@ public class UltraStarSongFormatTest
     }
 
     [Test]
+    public void ShouldNotAddLastEndOfPhrase()
+    {
+        SongMeta songMeta = UltraStarSongParser.ParseFile($"{folderPath}/Duet.txt").SongMeta;
+        string txt = UltraStarFormatWriter.ToUltraStarSongFormat(songMeta).Replace("\r\n", "\n");
+        Assert.IsTrue(txt.Contains("First Vocals!\nP2"));
+        Assert.IsTrue(txt.Contains("Second Vocals!\nE"));
+    }
+
+    [Test]
     public void ShouldNotContainP1InSoloSong()
     {
         SongMeta songMeta = UltraStarSongParser.ParseFile($"{folderPath}/Solo.txt").SongMeta;

--- a/UltraStar Play/Packages/playshared/Runtime/Songs/UltraStarSongFormat/UltraStarSongWriter/UltraStarSongWriter.cs
+++ b/UltraStar Play/Packages/playshared/Runtime/Songs/UltraStarSongFormat/UltraStarSongWriter/UltraStarSongWriter.cs
@@ -58,14 +58,12 @@ public static class UltraStarFormatWriter
             sb.AppendLine(voice.Id.ToString());
         }
         List<Sentence> sortedSentences = SongMetaUtils.GetSortedSentences(voice);
-        // Process the last sentence separately. A linebreak should not be appended after the last sentence.
-        foreach (Sentence sentence in sortedSentences.SkipLast(1))
+        for (int i = 0; i < sortedSentences.Count; i++)
         {
-            AppendSentence(sb, sentence, true);
-        }
-        if (sortedSentences.Count > 0)
-        {
-            AppendSentence(sb, sortedSentences.Last(), false);
+            Sentence sentence = sortedSentences[i];
+            // A linebreak should not be appended after the last sentence.
+            bool appendLinebreak = i < sortedSentences.Count - 1;
+            AppendSentence(sb, sentence, appendLinebreak);
         }
     }
 

--- a/UltraStar Play/Packages/playshared/Runtime/Songs/UltraStarSongFormat/UltraStarSongWriter/UltraStarSongWriter.cs
+++ b/UltraStar Play/Packages/playshared/Runtime/Songs/UltraStarSongFormat/UltraStarSongWriter/UltraStarSongWriter.cs
@@ -59,13 +59,18 @@ public static class UltraStarFormatWriter
         }
         List<Sentence> sortedSentences = new(voice.Sentences);
         sortedSentences.Sort(Sentence.comparerByStartBeat);
-        foreach (Sentence sentence in sortedSentences)
+        // Process the last sentence separately. A linebreak should not be appended after the last sentence.
+        foreach (Sentence sentence in sortedSentences.SkipLast(1))
         {
-            AppendSentence(sb, sentence);
+            AppendSentence(sb, sentence, true);
+        }
+        if (sortedSentences.Count > 0)
+        {
+            AppendSentence(sb, sortedSentences.Last(), false);
         }
     }
 
-    private static void AppendSentence(StringBuilder sb, Sentence sentence)
+    private static void AppendSentence(StringBuilder sb, Sentence sentence, bool appendLinebreak)
     {
         bool isEmpty = sentence.Notes.Count == 0;
         if (isEmpty)
@@ -79,15 +84,17 @@ public static class UltraStarFormatWriter
         {
             AppendNote(sb, note);
         }
-
-        // TODO: Linebreak timing could be optional but is required by some other tools, https://github.com/UltraStar-Deluxe/format/issues/64
-        sb.AppendLine($"- {sentence.ExtendedMaxBeat}");
-        // if (sentence.ExtendedMaxBeat > sentence.MaxBeat)
-        // {
-        //     sb.AppendLine($"- {sentence.ExtendedMaxBeat}");
-        // } else {
-        //     sb.AppendLine($"-");
-        // }
+        if (appendLinebreak)
+        {
+            // TODO: Linebreak timing could be optional but is required by some other tools, https://github.com/UltraStar-Deluxe/format/issues/64
+            sb.AppendLine($"- {sentence.ExtendedMaxBeat}");
+            // if (sentence.ExtendedMaxBeat > sentence.MaxBeat)
+            // {
+            //     sb.AppendLine($"- {sentence.ExtendedMaxBeat}");
+            // } else {
+            //     sb.AppendLine($"-");
+            // }
+        }
     }
 
     private static bool IsNotEmpty(Voice voice)

--- a/UltraStar Play/Packages/playshared/Runtime/Songs/UltraStarSongFormat/UltraStarSongWriter/UltraStarSongWriter.cs
+++ b/UltraStar Play/Packages/playshared/Runtime/Songs/UltraStarSongFormat/UltraStarSongWriter/UltraStarSongWriter.cs
@@ -57,8 +57,7 @@ public static class UltraStarFormatWriter
             // P1 is optional when only having one voice
             sb.AppendLine(voice.Id.ToString());
         }
-        List<Sentence> sortedSentences = new(voice.Sentences);
-        sortedSentences.Sort(Sentence.comparerByStartBeat);
+        List<Sentence> sortedSentences = SongMetaUtils.GetSortedSentences(voice);
         // Process the last sentence separately. A linebreak should not be appended after the last sentence.
         foreach (Sentence sentence in sortedSentences.SkipLast(1))
         {
@@ -78,8 +77,7 @@ public static class UltraStarFormatWriter
             return;
         }
 
-        List<Note> sortedNotes = new(sentence.Notes);
-        sortedNotes.Sort(Note.comparerByStartBeat);
+        List<Note> sortedNotes = SongMetaUtils.GetSortedNotes(sentence);
         foreach (Note note in sortedNotes)
         {
             AppendNote(sb, note);


### PR DESCRIPTION
### What does this PR do?

Fixes the issue where the editor saved song files with an additional end-of-phrase marker after the last note, as described in #573.

### Closes Issue(s)

#573

### Additional Notes

There is a wiki page with an example song file with extra end-of-phrase markers that needs to be updated if this gets merged.
https://github.com/UltraStar-Deluxe/Play/wiki/UltraStar-txt-File-Format
